### PR TITLE
use "rspack-plugin-virtual-module" replace "webpack-virtual-modules"

### DIFF
--- a/packages/rsmax-cli/package.json
+++ b/packages/rsmax-cli/package.json
@@ -71,6 +71,7 @@
     "resolve": "^1.12.0",
     "rslog": "^1.2.3",
     "rspack-chain": "^1.2.4",
+    "rspack-plugin-virtual-module": "^1.0.0",
     "schema-utils": "^2.6.1",
     "style-loader": "^4.0.0",
     "webpack-virtual-modules": "^0.6.2",

--- a/packages/rsmax-cli/package.json
+++ b/packages/rsmax-cli/package.json
@@ -42,7 +42,7 @@
     "@rsmax/runtime": "workspace:*",
     "@rsmax/shared": "workspace:*",
     "@rsmax/web": "workspace:*",
-    "@rspack/core": "npm:@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246",
+    "@rspack/core": "^1.3.10",
     "@rspack/dev-server": "^1.1.1",
     "babel-loader": "^9.1.3",
     "babel-plugin-module-resolver": "^5.0.2",

--- a/packages/rsmax-cli/src/build/entries/VirtualEntry.ts
+++ b/packages/rsmax-cli/src/build/entries/VirtualEntry.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import VirtualModulesPlugin from 'webpack-virtual-modules';
+import { RspackVirtualModulePlugin } from 'rspack-plugin-virtual-module';
 import Builder from '../Builder';
 import NormalEntry from './NormalEntry';
 import { replaceExtension } from '../utils/paths';
@@ -17,7 +17,7 @@ export default class VirtualEntry extends NormalEntry {
     this.virtualPath = path.resolve(
       replaceExtension(this.filename, this.filename.endsWith('.ts') ? '.entry.ts' : '.entry.js')
     );
-    this.virtualModule = new VirtualModulesPlugin({
+    this.virtualModule = new RspackVirtualModulePlugin({
       [this.virtualPath]: this.outputSource(),
     });
   }
@@ -42,7 +42,6 @@ export default class VirtualEntry extends NormalEntry {
         this.virtualModule.writeModule(this.virtualPath, this.outputSource());
       }
       const dep = new EntryDependency(this.virtualPath);
-      // rspack 中 addEntry 不允许加入虚拟文件，所以写入虚拟模块入口时需要先落盘 this.virtualPath 文件
       compilation.addEntry('', dep, { name: this.name }, err => {
         if (err) {
           console.error(err);

--- a/packages/rsmax-cli/src/build/webpack/baseConfig.ts
+++ b/packages/rsmax-cli/src/build/webpack/baseConfig.ts
@@ -27,11 +27,6 @@ export default function baseConfig(config: Config, builder: Builder) {
     },
   ]);
 
-  config.experiments({
-    // @ts-ignore
-    useInputFileSystem: true,
-  });
-
   if (process.env.NODE_ENV === 'production') {
     config.clear();
   }

--- a/packages/rsmax-cli/src/build/webpack/config.mini.ts
+++ b/packages/rsmax-cli/src/build/webpack/config.mini.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
-import * as path from 'node:path';
+import path from 'node:path';
 import Config from 'rspack-chain';
-import VirtualModulesPlugin from 'webpack-virtual-modules';
+import { RspackVirtualModulePlugin } from 'rspack-plugin-virtual-module';
 import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
 import { execute } from '@rsdoctor/cli';
 import type { Options } from '@rsmax/types';
@@ -206,7 +206,7 @@ export default function webpackConfig(builder: Builder): Configuration {
     path.resolve(__dirname, '../../../template/app-runtime-options.js.ejs'),
     'utf-8'
   );
-  const runtimeOptionsPath = slash('node_modules/@rsmax/apply-runtime-options.js');
+  const runtimeOptionsPath = slash('@rsmax/apply-runtime-options.js');
   config.entry(appEntry!.name).prepend('@rsmax/apply-runtime-options');
 
   const runtimeOptions = {
@@ -219,7 +219,7 @@ export default function webpackConfig(builder: Builder): Configuration {
     appEvents: '[]',
   };
 
-  const virtualModules = new VirtualModulesPlugin({
+  const virtualModules = new RspackVirtualModulePlugin({
     [runtimeOptionsPath]: ejs.render(runtimeOptionsTemplate, runtimeOptions, { debug: false }),
   });
   config.plugin('rspack-virtual-modules').use(virtualModules);

--- a/packages/rsmax-cli/src/build/webpack/config.miniComponent.ts
+++ b/packages/rsmax-cli/src/build/webpack/config.miniComponent.ts
@@ -2,7 +2,7 @@ import * as path from 'node:path';
 import fs from 'node:fs';
 import Config from 'rspack-chain';
 import type { Options } from '@rsmax/types';
-import VirtualModulesPlugin from 'webpack-virtual-modules';
+import { RspackVirtualModulePlugin } from 'rspack-plugin-virtual-module';
 import { slash } from '@rsmax/shared';
 import ejs from 'ejs';
 import { moduleMatcher, targetExtensions } from '../../extensions';
@@ -191,7 +191,7 @@ export default function webpackConfig(builder: Builder): Configuration {
     appEvents: '[]',
   };
 
-  const virtualModules = new VirtualModulesPlugin({
+  const virtualModules = new RspackVirtualModulePlugin({
     [runtimeOptionsPath]: ejs.render(runtimeOptionsTemplate, runtimeOptions, { debug: false }),
   });
   config.plugin('rspack-virtual-modules').use(virtualModules);

--- a/packages/rsmax-cli/src/build/webpack/config.miniPlugin.ts
+++ b/packages/rsmax-cli/src/build/webpack/config.miniPlugin.ts
@@ -2,7 +2,7 @@ import * as path from 'node:path';
 import { rspack, Configuration } from '@rspack/core';
 import Config from 'rspack-chain';
 import type { Options } from '@rsmax/types';
-import VirtualModulesPlugin from 'webpack-virtual-modules';
+import { RspackVirtualModulePlugin } from 'rspack-plugin-virtual-module';
 import { slash } from '@rsmax/shared';
 import ejs from 'ejs';
 import { moduleMatcher, targetExtensions } from '../../extensions';
@@ -195,7 +195,7 @@ export default function webpackConfig(builder: Builder): Configuration {
     appEvents: '[]',
   };
 
-  const virtualModules = new VirtualModulesPlugin({
+  const virtualModules = new RspackVirtualModulePlugin({
     [runtimeOptionsPath]: ejs.render(runtimeOptionsTemplate, runtimeOptions, { debug: false }),
   });
   config.plugin('rspack-virtual-modules').use(virtualModules);

--- a/packages/rsmax-plugin-error-screen/package.json
+++ b/packages/rsmax-plugin-error-screen/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@rsmax/redbox-react": "^1.0.3",
     "@rsmax/shared": "workspace:*",
-    "webpack-virtual-modules": "^0.6.2"
+    "rspack-plugin-virtual-module": "^1.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.0",

--- a/packages/rsmax-plugin-error-screen/src/index.ts
+++ b/packages/rsmax-plugin-error-screen/src/index.ts
@@ -1,6 +1,6 @@
 import * as path from 'node:path';
 import * as fs from 'node:fs';
-import VirtualModulesPlugin from 'webpack-virtual-modules';
+import { RspackVirtualModulePlugin } from 'rspack-plugin-virtual-module';
 import { slash } from '@rsmax/shared';
 
 export default (_: any, { cwd, rootDir }: { cwd: string; rootDir: string }) => {
@@ -23,8 +23,8 @@ export default (_: any, { cwd, rootDir }: { cwd: string; rootDir: string }) => {
   }
   const errorBoundaryFile = path.resolve(__dirname, './ErrorBoundary.js');
 
-  const virtualModules = new VirtualModulesPlugin({
-    'node_modules/@rsmax/plugin-error-screen/runtime.js': `
+  const virtualModules = new RspackVirtualModulePlugin({
+    '@rsmax/plugin-error-screen/runtime.js': `
         import React from 'react';
         import { View } from 'rsmax/one';
         import ErrorScreen from '${slash(errorScreenFile)}';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -415,10 +415,10 @@ importers:
         version: 7.27.1
       '@rsdoctor/cli':
         specifier: ^1.1.2
-        version: 1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
+        version: 1.1.2(@rspack/core@1.3.10(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
       '@rsdoctor/rspack-plugin':
         specifier: ^1.1.2
-        version: 1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
+        version: 1.1.2(@rspack/core@1.3.10(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
       '@rsmax/build-store':
         specifier: workspace:*
         version: link:../rsmax-build-store
@@ -447,11 +447,11 @@ importers:
         specifier: workspace:*
         version: link:../rsmax-web
       '@rspack/core':
-        specifier: npm:@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246
-        version: '@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17)'
+        specifier: ^1.3.10
+        version: 1.3.10(@swc/helpers@0.5.17)
       '@rspack/dev-server':
         specifier: ^1.1.1
-        version: 1.1.1(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(@types/express@4.17.21)(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
+        version: 1.1.1(@rspack/core@1.3.10(@swc/helpers@0.5.17))(@types/express@4.17.21)(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
       babel-loader:
         specifier: ^9.1.3
         version: 9.2.1(@babel/core@7.27.1)(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
@@ -478,7 +478,7 @@ importers:
         version: 3.6.0
       css-loader:
         specifier: ^6.7.0
-        version: 6.11.0(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
+        version: 6.11.0(@rspack/core@1.3.10(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
       detect-port:
         specifier: ^1.3.0
         version: 1.6.1
@@ -496,7 +496,7 @@ importers:
         version: 4.21.2
       html-webpack-plugin:
         specifier: ^5.5.0
-        version: 5.6.3(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
+        version: 5.6.3(@rspack/core@1.3.10(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
       htmlparser2:
         specifier: ^4.0.0
         version: 4.1.0
@@ -511,7 +511,7 @@ importers:
         version: 8.5.3
       postcss-loader:
         specifier: ^8.0.0
-        version: 8.1.1(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(postcss@8.5.3)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
+        version: 8.1.1(@rspack/core@1.3.10(@swc/helpers@0.5.17))(postcss@8.5.3)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
       postcss-noop:
         specifier: ^1.0.1
         version: 1.0.1
@@ -626,7 +626,7 @@ importers:
         version: 27.5.1
       less-loader:
         specifier: ^12.2.0
-        version: 12.3.0(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(less@4.3.0)(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
+        version: 12.3.0(@rspack/core@1.3.10(@swc/helpers@0.5.17))(less@4.3.0)(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
       memfs:
         specifier: ^4.17.1
         version: 4.17.1
@@ -3140,63 +3140,6 @@ packages:
 
   '@rsmax/xhs@1.1.1':
     resolution: {integrity: sha512-wGwKNscToSjkCchLLEWlqdbHvdQiQIh8GQCqy9Gzl0h0KGBpbUhJwvCgnq1aiYYF3/1FAz8t7Ioay5rwi2Zsow==}
-
-  '@rspack-canary/binding-darwin-arm64@1.3.11-canary-8548f2b8-20250515085246':
-    resolution: {integrity: sha512-ecpU3gg9nR4/BlxhHe02Qq9Apk8Ame9lSqyz3G9Nizrsb9OT2dpX6yNJxb9JTUPHRQD50jGqE64kvm8JHzysBg==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rspack-canary/binding-darwin-x64@1.3.11-canary-8548f2b8-20250515085246':
-    resolution: {integrity: sha512-HSn+YpHls9ht1DW6vyJ6TPUtZJle9nv23cFZYbzLMVk7kOn7R8DEK+K2MRVdGNsH/MbhShwLapL52wUokp8VlA==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rspack-canary/binding-linux-arm64-gnu@1.3.11-canary-8548f2b8-20250515085246':
-    resolution: {integrity: sha512-7bIH0I6bz+m1ER7B3mJOtMtwH2znSBEE04REwb+sn3tpFgxRtnf6gcuRBzXsIzFCd6kuI/26Ox3aRR5NdpEP1Q==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack-canary/binding-linux-arm64-musl@1.3.11-canary-8548f2b8-20250515085246':
-    resolution: {integrity: sha512-WZe8+rM/a5TxJh+gxT7Xvn/gdvJ4KJS2A/nMCxlMrz4OTheHQGCZ7BxuXNCHl9RAY2j8mkA3/4j9JeqjHnDrAQ==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack-canary/binding-linux-x64-gnu@1.3.11-canary-8548f2b8-20250515085246':
-    resolution: {integrity: sha512-eu6qWcldwPT94yZC5AhXAE6bNkBvnNUAxXscF3eBZbl8iOffGX/j9CvEU94QjiSiBkrj/DF3SWEar9vHLFdNgw==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack-canary/binding-linux-x64-musl@1.3.11-canary-8548f2b8-20250515085246':
-    resolution: {integrity: sha512-wJ0S3td/rsDls4ELQkXPeAFZ2qY0TXXXf/hW84Xp7bjPpXLNwoi/gZxGUIZRuq6mxjiHu4sRgvQylukfqNC1pA==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack-canary/binding-win32-arm64-msvc@1.3.11-canary-8548f2b8-20250515085246':
-    resolution: {integrity: sha512-4BAmRbxLsUWnCCweMIV/Wvql+BNaNjuKex1IDQNrusJaOo8ZuXl/G9xxqWO2BGliXuWupRY0KsJ7GPfzJ8jN/w==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rspack-canary/binding-win32-ia32-msvc@1.3.11-canary-8548f2b8-20250515085246':
-    resolution: {integrity: sha512-ZW3bZ3J6YjcPcm39zMANlcMJ/92ymyqWdIqeJQzDcoQD+eY/M1jbt3IcXMpxbXfpcZMNXejq8i2XoZOKXYhcnw==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rspack-canary/binding-win32-x64-msvc@1.3.11-canary-8548f2b8-20250515085246':
-    resolution: {integrity: sha512-DR+pa7AKUXWvlBsmgH95I2vsESUdAtBkGXyH34t+QBA5t+JN8wkxWEOyC4e2UullZBMvPF3b6QUZZBXXyXtVRw==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rspack-canary/binding@1.3.11-canary-8548f2b8-20250515085246':
-    resolution: {integrity: sha512-mYAk+8eG63BJKLWvCxgSTPXb7fmIbL+wFTjBKpFGqPWE+4SkxDyhVr2q2rlXWXubYPnPIcsckJj3ymjVaZXnXA==}
-
-  '@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246':
-    resolution: {integrity: sha512-a7z2llBpXhg/Lqwesy/yfT2YoJHZa4hgq3XsuvwoSVk9W7/Cuc6xsOsXuwNikT/pEbU41gjEp1PgctJ7hF7qvg==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@swc/helpers': '>=0.5.1'
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
 
   '@rspack/binding-darwin-arm64@1.3.10':
     resolution: {integrity: sha512-0k/j8OeMSVm5u5Nzckp9Ie7S7hprnvNegebnGr+L6VCyD7sMqm4m+4rLHs99ZklYdH0dZtY2+LrzrtjUZCqfew==}
@@ -13558,25 +13501,6 @@ snapshots:
       picocolors: 1.1.1
       source-map: 0.7.4
 
-  '@rsdoctor/cli@1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))':
-    dependencies:
-      '@rsdoctor/client': 1.1.2
-      '@rsdoctor/sdk': 1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
-      '@rsdoctor/types': 1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
-      '@rsdoctor/utils': 1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
-      axios: 1.9.0
-      ora: 5.4.1
-      picocolors: 1.1.1
-      tslib: 2.8.1
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-      - webpack
-
   '@rsdoctor/cli@1.1.2(@rspack/core@1.3.10(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))':
     dependencies:
       '@rsdoctor/client': 1.1.2
@@ -13597,32 +13521,6 @@ snapshots:
       - webpack
 
   '@rsdoctor/client@1.1.2': {}
-
-  '@rsdoctor/core@1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))':
-    dependencies:
-      '@rsbuild/plugin-check-syntax': 1.3.0
-      '@rsdoctor/graph': 1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
-      '@rsdoctor/sdk': 1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
-      '@rsdoctor/types': 1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
-      '@rsdoctor/utils': 1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
-      axios: 1.9.0
-      browserslist-load-config: 1.0.0
-      enhanced-resolve: 5.12.0
-      filesize: 10.1.6
-      fs-extra: 11.3.0
-      lodash: 4.17.21
-      path-browserify: 1.0.1
-      semver: 7.7.1
-      source-map: 0.7.4
-      webpack-bundle-analyzer: 4.10.2
-    transitivePeerDependencies:
-      - '@rsbuild/core'
-      - '@rspack/core'
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-      - webpack
 
   '@rsdoctor/core@1.1.2(@rspack/core@1.3.10(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))':
     dependencies:
@@ -13650,20 +13548,6 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/graph@1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))':
-    dependencies:
-      '@rsdoctor/types': 1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
-      '@rsdoctor/utils': 1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
-      lodash.unionby: 4.8.0
-      socket.io: 4.8.1
-      source-map: 0.7.4
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - webpack
-
   '@rsdoctor/graph@1.1.2(@rspack/core@1.3.10(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))':
     dependencies:
       '@rsdoctor/types': 1.1.2(@rspack/core@1.3.10(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
@@ -13674,23 +13558,6 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
-      - supports-color
-      - utf-8-validate
-      - webpack
-
-  '@rsdoctor/rspack-plugin@1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))':
-    dependencies:
-      '@rsdoctor/core': 1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
-      '@rsdoctor/graph': 1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
-      '@rsdoctor/sdk': 1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
-      '@rsdoctor/types': 1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
-      '@rsdoctor/utils': 1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
-      '@rspack/core': '@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17)'
-      lodash: 4.17.21
-    transitivePeerDependencies:
-      - '@rsbuild/core'
-      - bufferutil
-      - debug
       - supports-color
       - utf-8-validate
       - webpack
@@ -13708,31 +13575,6 @@ snapshots:
       - '@rsbuild/core'
       - bufferutil
       - debug
-      - supports-color
-      - utf-8-validate
-      - webpack
-
-  '@rsdoctor/sdk@1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))':
-    dependencies:
-      '@rsdoctor/client': 1.1.2
-      '@rsdoctor/graph': 1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
-      '@rsdoctor/types': 1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
-      '@rsdoctor/utils': 1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
-      '@types/fs-extra': 11.0.4
-      body-parser: 1.20.3
-      cors: 2.8.5
-      dayjs: 1.11.13
-      fs-extra: 11.3.0
-      json-cycle: 1.5.0
-      lodash: 4.17.21
-      open: 8.4.2
-      sirv: 2.0.4
-      socket.io: 4.8.1
-      source-map: 0.7.4
-      tapable: 2.2.1
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - bufferutil
       - supports-color
       - utf-8-validate
       - webpack
@@ -13762,16 +13604,6 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/types@1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))':
-    dependencies:
-      '@types/connect': 3.4.38
-      '@types/estree': 1.0.5
-      '@types/tapable': 2.2.7
-      source-map: 0.7.4
-    optionalDependencies:
-      '@rspack/core': '@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17)'
-      webpack: 5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17))
-
   '@rsdoctor/types@1.1.2(@rspack/core@1.3.10(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))':
     dependencies:
       '@types/connect': 3.4.38
@@ -13781,30 +13613,6 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 1.3.10(@swc/helpers@0.5.17)
       webpack: 5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17))
-
-  '@rsdoctor/utils@1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))':
-    dependencies:
-      '@babel/code-frame': 7.26.2
-      '@rsdoctor/types': 1.1.2(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
-      '@types/estree': 1.0.5
-      acorn: 8.14.1
-      acorn-import-attributes: 1.9.5(acorn@8.14.1)
-      acorn-walk: 8.3.4
-      connect: 3.7.0
-      deep-eql: 4.1.4
-      envinfo: 7.14.0
-      filesize: 10.1.6
-      fs-extra: 11.3.0
-      get-port: 5.1.1
-      json-stream-stringify: 3.0.1
-      lines-and-columns: 2.0.4
-      picocolors: 1.1.1
-      rslog: 1.2.3
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - supports-color
-      - webpack
 
   '@rsdoctor/utils@1.1.2(@rspack/core@1.3.10(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))':
     dependencies:
@@ -14301,54 +14109,6 @@ snapshots:
       - react
       - supports-color
 
-  '@rspack-canary/binding-darwin-arm64@1.3.11-canary-8548f2b8-20250515085246':
-    optional: true
-
-  '@rspack-canary/binding-darwin-x64@1.3.11-canary-8548f2b8-20250515085246':
-    optional: true
-
-  '@rspack-canary/binding-linux-arm64-gnu@1.3.11-canary-8548f2b8-20250515085246':
-    optional: true
-
-  '@rspack-canary/binding-linux-arm64-musl@1.3.11-canary-8548f2b8-20250515085246':
-    optional: true
-
-  '@rspack-canary/binding-linux-x64-gnu@1.3.11-canary-8548f2b8-20250515085246':
-    optional: true
-
-  '@rspack-canary/binding-linux-x64-musl@1.3.11-canary-8548f2b8-20250515085246':
-    optional: true
-
-  '@rspack-canary/binding-win32-arm64-msvc@1.3.11-canary-8548f2b8-20250515085246':
-    optional: true
-
-  '@rspack-canary/binding-win32-ia32-msvc@1.3.11-canary-8548f2b8-20250515085246':
-    optional: true
-
-  '@rspack-canary/binding-win32-x64-msvc@1.3.11-canary-8548f2b8-20250515085246':
-    optional: true
-
-  '@rspack-canary/binding@1.3.11-canary-8548f2b8-20250515085246':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': '@rspack-canary/binding-darwin-arm64@1.3.11-canary-8548f2b8-20250515085246'
-      '@rspack/binding-darwin-x64': '@rspack-canary/binding-darwin-x64@1.3.11-canary-8548f2b8-20250515085246'
-      '@rspack/binding-linux-arm64-gnu': '@rspack-canary/binding-linux-arm64-gnu@1.3.11-canary-8548f2b8-20250515085246'
-      '@rspack/binding-linux-arm64-musl': '@rspack-canary/binding-linux-arm64-musl@1.3.11-canary-8548f2b8-20250515085246'
-      '@rspack/binding-linux-x64-gnu': '@rspack-canary/binding-linux-x64-gnu@1.3.11-canary-8548f2b8-20250515085246'
-      '@rspack/binding-linux-x64-musl': '@rspack-canary/binding-linux-x64-musl@1.3.11-canary-8548f2b8-20250515085246'
-      '@rspack/binding-win32-arm64-msvc': '@rspack-canary/binding-win32-arm64-msvc@1.3.11-canary-8548f2b8-20250515085246'
-      '@rspack/binding-win32-ia32-msvc': '@rspack-canary/binding-win32-ia32-msvc@1.3.11-canary-8548f2b8-20250515085246'
-      '@rspack/binding-win32-x64-msvc': '@rspack-canary/binding-win32-x64-msvc@1.3.11-canary-8548f2b8-20250515085246'
-
-  '@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17)':
-    dependencies:
-      '@module-federation/runtime-tools': 0.13.1
-      '@rspack/binding': '@rspack-canary/binding@1.3.11-canary-8548f2b8-20250515085246'
-      '@rspack/lite-tapable': 1.0.1
-      caniuse-lite: 1.0.30001718
-    optionalDependencies:
-      '@swc/helpers': 0.5.17
-
   '@rspack/binding-darwin-arm64@1.3.10':
     optional: true
 
@@ -14396,26 +14156,6 @@ snapshots:
       caniuse-lite: 1.0.30001718
     optionalDependencies:
       '@swc/helpers': 0.5.17
-
-  '@rspack/dev-server@1.1.1(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(@types/express@4.17.21)(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))':
-    dependencies:
-      '@rspack/core': '@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17)'
-      chokidar: 3.6.0
-      express: 4.21.2
-      http-proxy-middleware: 2.0.9(@types/express@4.17.21)
-      mime-types: 2.1.35
-      p-retry: 6.2.1
-      webpack-dev-middleware: 7.4.2(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
-      webpack-dev-server: 5.2.0(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))
-      ws: 8.18.2
-    transitivePeerDependencies:
-      - '@types/express'
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-      - webpack
-      - webpack-cli
 
   '@rspack/dev-server@1.1.1(@rspack/core@1.3.10(@swc/helpers@0.5.17))(@types/express@4.17.21)(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17)))':
     dependencies:
@@ -16481,20 +16221,6 @@ snapshots:
       postcss-selector-parser: 7.1.0
       postcss-value-parser: 4.2.0
 
-  css-loader@6.11.0(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17))):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.5.3)
-      postcss: 8.5.3
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.3)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.3)
-      postcss-modules-scope: 3.2.1(postcss@8.5.3)
-      postcss-modules-values: 4.0.0(postcss@8.5.3)
-      postcss-value-parser: 4.2.0
-      semver: 7.7.1
-    optionalDependencies:
-      '@rspack/core': '@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17)'
-      webpack: 5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17))
-
   css-loader@6.11.0(@rspack/core@1.3.10(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17))):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.3)
@@ -18211,17 +17937,6 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.39.0
 
-  html-webpack-plugin@5.6.3(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17))):
-    dependencies:
-      '@types/html-minifier-terser': 6.1.0
-      html-minifier-terser: 6.1.0
-      lodash: 4.17.21
-      pretty-error: 4.0.0
-      tapable: 2.2.1
-    optionalDependencies:
-      '@rspack/core': '@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17)'
-      webpack: 5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17))
-
   html-webpack-plugin@5.6.3(@rspack/core@1.3.10(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17))):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
@@ -19208,13 +18923,6 @@ snapshots:
       - debug
       - encoding
       - supports-color
-
-  less-loader@12.3.0(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(less@4.3.0)(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17))):
-    dependencies:
-      less: 4.3.0
-    optionalDependencies:
-      '@rspack/core': '@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17)'
-      webpack: 5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17))
 
   less-loader@12.3.0(@rspack/core@1.3.10(@swc/helpers@0.5.17))(less@4.3.0)(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17))):
     dependencies:
@@ -20645,18 +20353,6 @@ snapshots:
     dependencies:
       cosmiconfig: 5.2.1
       import-cwd: 2.1.0
-
-  postcss-loader@8.1.1(@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17))(postcss@8.5.3)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17))):
-    dependencies:
-      cosmiconfig: 9.0.0(typescript@4.9.5)
-      jiti: 1.21.7
-      postcss: 8.5.3
-      semver: 7.7.1
-    optionalDependencies:
-      '@rspack/core': '@rspack-canary/core@1.3.11-canary-8548f2b8-20250515085246(@swc/helpers@0.5.17)'
-      webpack: 5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17))
-    transitivePeerDependencies:
-      - typescript
 
   postcss-loader@8.1.1(@rspack/core@1.3.10(@swc/helpers@0.5.17))(postcss@8.5.3)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.24(@swc/helpers@0.5.17))):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -533,6 +533,9 @@ importers:
       rspack-chain:
         specifier: ^1.2.4
         version: 1.2.4
+      rspack-plugin-virtual-module:
+        specifier: ^1.0.0
+        version: 1.0.0
       schema-utils:
         specifier: ^2.6.1
         version: 2.7.1
@@ -832,9 +835,9 @@ importers:
       '@rsmax/shared':
         specifier: workspace:*
         version: link:../rsmax-shared
-      webpack-virtual-modules:
-        specifier: ^0.6.2
-        version: 0.6.2
+      rspack-plugin-virtual-module:
+        specifier: ^1.0.0
+        version: 1.0.0
     devDependencies:
       '@types/react':
         specifier: ^18.3.0


### PR DESCRIPTION
webpack-virtual-modules 在 当前 rspack 环境下并不可正式使用。所以更新为 rspack-plugin-virtual-module.

虽然 rspack-plugin-virtual-module 会导致内存泄露问题，但已提交对应 PR 修复 https://github.com/rspack-contrib/rspack-plugin-virtual-module/pull/28 。等待更新版本即可