### PR TITLE
refactor: 移除 VirtualEntry 中冗余的 fs.writeFileSync 和 console.error

### DIFF
--- a/packages/rsmax-cli/src/build/entries/VirtualEntry.ts
+++ b/packages/rsmax-cli/src/build/entries/VirtualEntry.ts
@@ -40,11 +40,9 @@ export default class VirtualEntry extends NormalEntry {
         this.virtualModule.apply(compiler);
         this.virtualModule.writeModule(this.virtualPath, this.outputSource());
       }
-      fs.writeFileSync(this.virtualPath, this.outputSource());
       const dep = EntryPlugin.createDependency(this.virtualPath);
       compilation.addEntry('', dep, { name: this.name }, err => {
         if (err) {
-          console.error(err);
           reject(err);
         }
         resolve();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Prevents unintended creation of on-disk files during virtual entry builds, avoiding stray artifacts and potential confusion.

* Refactor
  * Removes redundant console error logs during entry addition for cleaner build output; errors still fail builds as expected. No breaking changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->