### PR TITLE
refactor(cli): 将 rsdoctor 分析报告生成延迟从 3s 调整为 5s

### DIFF
--- a/packages/rsmax-cli/src/build/webpack/config.mini.ts
+++ b/packages/rsmax-cli/src/build/webpack/config.mini.ts
@@ -255,7 +255,7 @@ export default function webpackConfig(builder: Builder): Configuration {
       }).then(r => {
         logger.success('已生成分析报告');
       });
-    }, 3000);
+    }, 5000);
   }
 
   const context = {

--- a/packages/rsmax-cli/src/build/webpack/config.miniComponent.ts
+++ b/packages/rsmax-cli/src/build/webpack/config.miniComponent.ts
@@ -236,7 +236,7 @@ export default function webpackConfig(builder: Builder): Configuration {
       }).then(r => {
         logger.success('已生成分析报告');
       });
-    }, 3000);
+    }, 5000);
   }
 
   const context = {

--- a/packages/rsmax-cli/src/build/webpack/webBaseConfig.ts
+++ b/packages/rsmax-cli/src/build/webpack/webBaseConfig.ts
@@ -104,7 +104,7 @@ export default function webBaseConfig(config: Config, builder: Builder) {
       }).then(r => {
         logger.success('已生成分析报告');
       });
-    }, 3000);
+    }, 5000);
   }
 
   if (!builder.options.watch) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Increased the delay before triggering post-build analysis from 3s to 5s across CLI web and component builds. This improves the reliability of generating analysis reports by ensuring bundling has fully completed before analysis starts.
* **Chores**
  * Standardized the post-build analysis timing across related build configurations.
  * No changes to runtime behavior or public interfaces; impact is limited to build-time analysis execution timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->