### PR TITLE
revert: 恢复微信/支付宝/阿里 api

### DIFF
--- a/packages/rsmax-ali/package.json
+++ b/packages/rsmax-ali/package.json
@@ -7,23 +7,6 @@
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
   "typings": "./esm/index.d.ts",
-  "exports": {
-    "./types": {
-      "types": "./esm/types/index.d.ts",
-      "import": "./esm/types/index.js",
-      "require": "./cjs/types/index.js"
-    },
-    "./component": {
-      "types": "./esm/hostComponents/index.d.ts",
-      "import": "./esm/hostComponents/index.js",
-      "require": "./cjs/hostComponents/index.js"
-    },
-    "./node": {
-      "types": "./esm/node/index.d.ts",
-      "import": "./esm/node/index.js",
-      "require": "./cjs/node/index.js"
-    }
-  },
   "scripts": {
     "prebuild": "npm run clean",
     "build": "tsc",

--- a/packages/rsmax-ali/src/api.ts
+++ b/packages/rsmax-ali/src/api.ts
@@ -1,0 +1,401 @@
+import { promisify } from '@rsmax/framework-shared';
+
+/**
+ * 基础 API
+ */
+// 基础
+export const canIUse = my.canIUse;
+export const env = my.env;
+export const isIDE = my.isIDE;
+export const getLaunchOptionsSync = my.getLaunchOptionsSync;
+export const getEnterOptionsSync = my.getEnterOptionsSync;
+export const SDKVersion = my.SDKVersion;
+export const getAccountInfoSync = my.getAccountInfoSync;
+export const getAppIdSync = my.getAppIdSync;
+export const getRunScene = promisify(my.getRunScene);
+export const base64ToArrayBuffer = my.base64ToArrayBuffer;
+export const arrayBufferToBase64 = my.arrayBufferToBase64;
+// 性能
+// @ts-ignore
+export const getPerformance = my.getPerformance;
+// 调试
+// @ts-ignore
+export const setEnableDebug = promisify(my.setEnableDebug);
+// 应用级事件
+export const onAppShow = my.onAppShow;
+export const offAppShow = my.offAppShow;
+export const onAppHide = my.onAppHide;
+export const offAppHide = my.offAppHide;
+export const onPageNotFound = my.onPageNotFound;
+export const offPageNotFound = my.offPageNotFound;
+export const onUnhandledRejection = my.onUnhandledRejection;
+export const offUnhandledRejection = my.offUnhandledRejection;
+export const onError = my.onError;
+export const offError = my.offError;
+export const onComponentError = my.onComponentError;
+export const offComponentError = my.offComponentError;
+// @ts-ignore
+export const onLazyLoadError = my.onLazyLoadError;
+// @ts-ignore
+export const offLazyLoadError = my.offLazyLoadError;
+// 界面
+export const setNavigationBar = promisify(my.setNavigationBar);
+export const setNavigationBarTitle = promisify(my.setNavigationBarTitle);
+export const setNavigationBarColor = promisify(my.setNavigationBarColor);
+export const setNavigationBarBottomLineColor = promisify(my.setNavigationBarBottomLineColor);
+export const hideBackHome = promisify(my.hideBackHome);
+export const getTitleColor = promisify(my.getTitleColor);
+export const getMenuButtonBoundingClientRect = my.getMenuButtonBoundingClientRect;
+export const getLeftButtonsBoundingClientRect = my.getLeftButtonsBoundingClientRect;
+export const showNavigationBarLoading = promisify(my.showNavigationBarLoading);
+export const hideNavigationBarLoading = promisify(my.hideNavigationBarLoading);
+// 界面 - tabbar
+export const showTabBar = promisify(my.showTabBar);
+export const hideTabBar = promisify(my.hideTabBar);
+export const setTabBarBadge = promisify(my.setTabBarBadge);
+export const setTabBarItem = promisify(my.setTabBarItem);
+export const setTabBarStyle = promisify(my.setTabBarStyle);
+export const removeTabBarBadge = promisify(my.removeTabBarBadge);
+export const showTabBarRedDot = promisify(my.showTabBarRedDot);
+export const hideTabBarRedDot = my.hideTabBarRedDot;
+// 界面 - 路由
+export const switchTab = promisify(my.switchTab);
+export const navigateTo = promisify(my.navigateTo);
+export const navigateBack = promisify(my.navigateBack);
+export const redirectTo = promisify(my.redirectTo);
+export const reLaunch = promisify(my.reLaunch);
+// 界面 - 交互反馈
+export const showLoading = promisify(my.showLoading);
+export const hideLoading = promisify(my.hideLoading);
+export const showModal = promisify(my.showModal);
+export const alert = promisify(my.alert);
+export const showToast = promisify(my.showToast);
+export const hideToast = promisify(my.hideToast);
+export const showActionSheet = promisify(my.showActionSheet);
+export const confirm = promisify(my.confirm);
+export const prompt = promisify(my.prompt);
+export const enableAlertBeforeUnload = promisify(my.enableAlertBeforeUnload);
+export const disableAlertBeforeUnload = promisify(my.disableAlertBeforeUnload);
+// @ts-ignore
+export const showAppModal = promisify(my.showAppModal);
+// 界面 - 下拉刷新
+export const startPullDownRefresh = promisify(my.startPullDownRefresh);
+export const stopPullDownRefresh = promisify(my.stopPullDownRefresh);
+// 界面 - 联系人
+export const choosePhoneContact = promisify(my.choosePhoneContact);
+export const chooseAlipayContact = promisify(my.chooseAlipayContact);
+export const chooseContact = promisify(my.chooseContact);
+// 界面 - 选择城市
+export const chooseCity = promisify(my.chooseCity);
+export const chooseDistrict = promisify(my.chooseDistrict);
+export const regionPicker = promisify(my.regionPicker);
+// 界面 - 选择日期
+export const datePicker = promisify(my.datePicker);
+// 界面 - 动画
+export const createAnimation = promisify(my.createAnimation);
+// 界面 - 地图
+export const getMapInfo = promisify(my.getMapInfo);
+export const createMapContext = my.createMapContext;
+// 界面 - 计算路径
+export const calculateRoute = promisify(my.calculateRoute);
+// 界面 - 键盘
+export const hideKeyboard = my.hideKeyboard;
+// @ts-ignore
+export const getSelectedTextRange = promisify(my.getSelectedTextRange);
+// 界面 - 滚动
+export const pageScrollTo = promisify(my.pageScrollTo);
+// @ts-ignore
+export const setPageScrollable = promisify(my.setPageScrollable);
+// 界面 - 节点查询
+export const createSelectorQuery = my.createSelectorQuery;
+export const createIntersectionObserver = my.createIntersectionObserver;
+// 界面 - 选项选择器
+export const optionsSelect = promisify(my.optionsSelect);
+export const multiLevelSelect = promisify(my.multiLevelSelect);
+export const setBackgroundColor = promisify(my.setBackgroundColor);
+export const setBackgroundTextStyle = promisify(my.setBackgroundTextStyle);
+export const setCanPullDown = promisify(my.setCanPullDown);
+export const loadFontFace = promisify(my.loadFontFace);
+// 界面 - 跳转 - 小程序相互跳转
+export const navigateToMiniProgram = promisify(my.navigateToMiniProgram);
+export const navigateBackMiniProgram = promisify(my.navigateBackMiniProgram);
+// 界面 - 跳转  - 跳转支付宝应用或者页面
+// @ts-ignore
+export const openEmbeddedMiniProgram = promisify(my.openEmbeddedMiniProgram);
+// @ts-ignore
+export const openAlipayApp = promisify(my.app.openAlipayApp);
+// @ts-ignore
+export const openURL = promisify(my.app.openURL);
+// 界面 - 重启/退出小程序
+// @ts-ignore
+export const restartMiniProgram = promisify(my.restartMiniProgram);
+export const exitMiniProgram = promisify(my.exitMiniProgram);
+// 多媒体 -图片
+export const chooseImage = promisify(my.chooseImage);
+export const previewImage = promisify(my.previewImage);
+export const getImageInfo = promisify(my.getImageInfo);
+export const saveImageToPhotosAlbum = promisify(my.saveImageToPhotosAlbum);
+export const compressImage = promisify(my.compressImage);
+export const generateImageFromCode = promisify(my.generateImageFromCode);
+// 多媒体 - 视频
+export const chooseVideo = promisify(my.chooseVideo);
+export const getVideoInfo = my.getVideoInfo;
+export const saveVideoToPhotosAlbum = promisify(my.saveVideoToPhotosAlbum);
+export const createVideoContext = my.createVideoContext;
+// 多媒体 - 音频
+export const createInnerAudioContext = my.createInnerAudioContext;
+export const onAudioInterruptionBegin = my.onAudioInterruptionBegin;
+export const offAudioInterruptionBegin = my.offAudioInterruptionBegin;
+export const onAudioInterruptionEnd = my.onAudioInterruptionEnd;
+export const offAudioInterruptionEnd = my.offAudioInterruptionEnd;
+// 多媒体 - 录音
+export const getRecorderManager = my.getRecorderManager;
+export const getAvailableAudioSources = promisify(my.getAvailableAudioSources);
+// 多媒体 - lottie 动画
+export const createLottieContext = my.createLottieContext;
+// 多媒体 - 相机
+// @ts-ignore
+export const createCameraContext = my.createCameraContext;
+// 缓存
+export const setStorage = promisify(my.setStorage);
+export const setStorageSync = my.setStorageSync;
+export const getStorage = promisify(my.getStorage);
+export const getStorageSync = my.getStorageSync;
+export const getStorageInfo = promisify(my.getStorageInfo);
+export const getStorageInfoSync = my.getStorageInfoSync;
+export const removeStorage = promisify(my.removeStorage);
+export const removeStorageSync = my.removeStorageSync;
+export const clearStorage = promisify(my.clearStorage);
+export const clearStorageSync = my.clearStorageSync;
+// 缓存 - 预拉取
+export const getBackgroundFetchData = promisify(my.getBackgroundFetchData);
+// 文件
+export const openDocument = promisify(my.openDocument);
+export const saveFileToDisk = promisify(my.saveFileToDisk);
+export const detectFileType = promisify(my.detectFileType);
+export const getFileSystemManager = my.getFileSystemManager;
+// @ts-ignore
+export const chooseFileFromDisk = promisify(my.chooseFileFromDisk);
+// 位置
+export const getLocation = promisify(my.getLocation);
+export const getMainSelectedCity = promisify(my.ap.getMainSelectedCity);
+export const chooseLocation = promisify(my.chooseLocation);
+export const openLocation = promisify(my.openLocation);
+// 网络
+export const request = promisify(my.request);
+// 网络 - 上传
+export const uploadFile = promisify(my.uploadFile);
+// 网络 - 下载
+export const downloadFile = promisify(my.downloadFile);
+// 网络 - websocket
+export const connectSocket = promisify(my.connectSocket);
+export const closeSocket = promisify(my.closeSocket);
+export const sendSocketMessage = promisify(my.sendSocketMessage);
+export const onSocketOpen = my.onSocketOpen;
+export const offSocketOpen = my.offSocketOpen;
+export const onSocketMessage = my.onSocketMessage;
+export const offSocketMessage = my.offSocketMessage;
+export const onSocketError = my.onSocketError;
+export const offSocketError = my.offSocketError;
+export const onSocketClose = my.onSocketClose;
+export const offSocketClose = my.offSocketClose;
+// 设备 - 系统信息
+export const getSystemInfo = promisify(my.getSystemInfo);
+export const getSystemInfoSync = my.getSystemInfoSync;
+// @ts-ignore
+export const getDeviceBaseInfo = my.getDeviceBaseInfo;
+export const getSystemSetting = my.getSystemSetting;
+export const getWindowInfo = my.getWindowInfo;
+export const getAppBaseInfo = my.getAppBaseInfo;
+export const getAppAuthorizeSetting = my.getAppAuthorizeSetting;
+// 设备 - 网络状态
+export const getNetworkType = promisify(my.getNetworkType);
+export const onNetworkStatusChange = promisify(my.onNetworkStatusChange);
+export const offNetworkStatusChange = promisify(my.offNetworkStatusChange);
+// 设备 - 截屏
+export const setVisualEffectOnCapture = promisify(my.setVisualEffectOnCapture);
+// 设备 - 剪贴板
+export const getClipboard = promisify(my.getClipboard);
+export const setClipboard = promisify(my.setClipboard);
+// 设备 - 摇一摇
+export const watchShake = promisify(my.watchShake);
+// 设备 - 振动
+export const vibrate = promisify(my.vibrate);
+export const vibrateLong = promisify(my.vibrateLong);
+export const vibrateShort = promisify(my.vibrateShort);
+// 设备 - 加速度计
+export const startAccelerometer = promisify(my.startAccelerometer);
+export const stopAccelerometer = promisify(my.stopAccelerometer);
+export const onAccelerometerChange = my.onAccelerometerChange;
+export const offAccelerometerChange = my.offAccelerometerChange;
+// 设备 - 陀螺仪
+export const startGyroscope = promisify(my.startGyroscope);
+export const stopGyroscope = promisify(my.stopGyroscope);
+export const onGyroscopeChange = my.onGyroscopeChange;
+export const offGyroscopeChange = my.offGyroscopeChange;
+// 设备 - 罗盘
+export const startCompass = promisify(my.startCompass);
+export const stopCompass = promisify(my.stopCompass);
+export const onCompassChange = my.onCompassChange;
+export const offCompassChange = my.offCompassChange;
+// 设备 - 设备方向
+// @ts-ignore
+export const startDeviceMotionListening = promisify(my.startDeviceMotionListening);
+// @ts-ignore
+export const stopDeviceMotionListening = promisify(my.stopDeviceMotionListening);
+export const onDeviceMotionChange = my.onDeviceMotionChange;
+export const offDeviceMotionChange = my.offDeviceMotionChange;
+// 设备 - 拨打电话
+export const makePhoneCall = promisify(my.makePhoneCall);
+// 设备 - 获取服务器时间
+export const getServerTime = promisify(my.getServerTime);
+// 设备 - 用户截屏事件
+export const onUserCaptureScreen = my.onUserCaptureScreen;
+export const offUserCaptureScreen = my.offUserCaptureScreen;
+// 设备 - 屏幕亮度
+export const getScreenBrightness = promisify(my.getScreenBrightness);
+export const setScreenBrightness = promisify(my.setScreenBrightness);
+export const setKeepScreenOn = promisify(my.setKeepScreenOn);
+// 设备 - 设置
+export const getSetting = promisify(my.getSetting);
+export const openSetting = promisify(my.openSetting);
+// 设备 - 添加手机联系人
+export const addPhoneContact = promisify(my.addPhoneContact);
+// 设备 - 无障碍
+export const isScreenReaderEnabled = promisify(my.isScreenReaderEnabled);
+// 设备 - 权限引导
+export const showAuthGuide = promisify(my.showAuthGuide);
+// 设备 - 扫码
+export const scan = promisify(my.scan);
+// 设备 - 内存不足警告
+export const onMemoryWarning = my.onMemoryWarning;
+export const offMemoryWarning = my.offMemoryWarning;
+// 设备 - 获取手机电量
+export const getBatteryInfo = promisify(my.getBatteryInfo);
+export const getBatteryInfoSync = my.getBatteryInfoSync;
+// 设备 - 蓝牙 - 低功耗蓝牙
+export const onBLEConnectionStateChanged = my.onBLEConnectionStateChanged;
+export const offBLEConnectionStateChanged = my.offBLEConnectionStateChanged;
+export const getBLEDeviceServices = promisify(my.getBLEDeviceServices);
+export const connectBLEDevice = promisify(my.connectBLEDevice);
+export const disconnectBLEDevice = promisify(my.disconnectBLEDevice);
+export const getBLEDeviceCharacteristics = promisify(my.getBLEDeviceCharacteristics);
+export const setBLEMTU = promisify(my.setBLEMTU);
+export const getBLEMTU = promisify(my.getBLEMTU);
+export const notifyBLECharacteristicValueChange = promisify(my.notifyBLECharacteristicValueChange);
+export const onBLECharacteristicValueChange = my.onBLECharacteristicValueChange;
+export const offBLECharacteristicValueChange = my.offBLECharacteristicValueChange;
+export const writeBLECharacteristicValue = promisify(my.writeBLECharacteristicValue);
+export const readBLECharacteristicValue = promisify(my.readBLECharacteristicValue);
+export const getBLEDeviceRSSI = promisify(my.getBLEDeviceRSSI);
+export const getBLEDeviceStatus = promisify(my.getBLEDeviceStatus);
+// 设备 - 蓝牙 - 传统蓝牙
+export const openBluetoothAdapter = promisify(my.openBluetoothAdapter);
+export const closeBluetoothAdapter = promisify(my.closeBluetoothAdapter);
+export const getBluetoothAdapterState = promisify(my.getBluetoothAdapterState);
+export const onBluetoothAdapterStateChange = my.onBluetoothAdapterStateChange;
+export const offBluetoothAdapterStateChange = my.offBluetoothAdapterStateChange;
+export const onBluetoothDeviceFound = my.onBluetoothDeviceFound;
+export const offBluetoothDeviceFound = my.offBluetoothDeviceFound;
+export const startBluetoothDevicesDiscovery = promisify(my.startBluetoothDevicesDiscovery);
+export const stopBluetoothDevicesDiscovery = promisify(my.stopBluetoothDevicesDiscovery);
+export const getBluetoothDevices = promisify(my.getBluetoothDevices);
+export const getConnectedBluetoothDevices = promisify(my.getConnectedBluetoothDevices);
+export const makeBluetoothPair = promisify(my.makeBluetoothPair);
+export const getBluetoothPairs = promisify(my.getBluetoothPairs);
+export const cancelBluetoothPair = promisify(my.cancelBluetoothPair);
+// 设备 - 蓝牙 - iBeacon(近场定位技术)
+export const getBeacons = promisify(my.getBeacons);
+export const startBeaconDiscovery = promisify(my.startBeaconDiscovery);
+export const stopBeaconDiscovery = promisify(my.stopBeaconDiscovery);
+export const onBeaconUpdate = my.onBeaconUpdate;
+export const offBeaconUpdate = my.offBeaconUpdate;
+export const onBeaconServiceChange = my.onBeaconServiceChange;
+export const offBeaconServiceChange = my.offBeaconServiceChange;
+// 设备 - Wi-Fi
+export const startWifi = promisify(my.startWifi);
+export const stopWifi = promisify(my.stopWifi);
+export const connectWifi = promisify(my.connectWifi);
+export const getWifiList = promisify(my.getWifiList);
+export const onWifiConnected = my.onWifiConnected;
+export const offWifiConnected = my.offWifiConnected;
+export const onGetWifiList = my.onGetWifiList;
+export const offGetWifiList = my.offGetWifiList;
+export const getConnectedWifi = promisify(my.getConnectedWifi);
+// 设备 - 短信
+// @ts-ignore
+export const sendSms = promisify(my.sendSms);
+// Worker
+export const createWorker = my.createWorker;
+// 数据安全
+export const rsa = promisify(my.rsa);
+// 分享
+export const showSharePanel = my.showSharePanel;
+export const hideShareMenu = promisify(my.hideShareMenu);
+export const showShareMenu = promisify(my.showShareMenu);
+// 收藏
+// @ts-ignore
+export const isCollected = promisify(my.isCollected);
+// 自定义通用菜单
+export const hideAddToDesktopMenu = promisify(my.hideAddToDesktopMenu);
+export const hideAllAddToDesktopMenu = promisify(my.hideAllAddToDesktopMenu);
+// 更新管理
+export const getUpdateManager = my.getUpdateManager;
+// web-view 组件控制
+export const createWebViewContext = my.createWebViewContext;
+// 升级支付宝最新版本
+export const updateAlipayClient = promisify(my.ap.updateAlipayClient);
+// 隐私信息授权
+// @ts-ignore
+export const requirePrivacyAuthorize = promisify(my.requirePrivacyAuthorize);
+// @ts-ignore
+export const openPrivacyContract = promisify(my.openPrivacyContract);
+// @ts-ignore
+export const onNeedPrivacyAuthorization = my.onNeedPrivacyAuthorization;
+// @ts-ignore
+export const getPrivacySetting = promisify(my.getPrivacySetting);
+// 小程序广告
+export const createRewardedAd = promisify(my.createRewardedAd);
+// @ts-ignore
+export const createInterstitialAd = promisify(my.createInterstitialAd);
+/**
+ * 开放能力 API
+ */
+// 支付
+export const tradePay = promisify(my.tradePay);
+// 用户授权
+export const getAuthCode = promisify(my.getAuthCode);
+// 会员
+export const getOpenUserInfo = promisify(my.getOpenUserInfo);
+export const getAddress = promisify(my.getAddress);
+export const getPhoneNumber = promisify(my.getPhoneNumber);
+// 周期扣款
+export const paySignCenter = promisify(my.paySignCenter);
+// 商家会员卡
+// @ts-ignore
+export const openCardList = promisify(my.openCardList);
+// @ts-ignore
+export const openCardDetail = promisify(my.openCardDetail);
+// @ts-ignore
+export const openMerchantCardList = promisify(my.openMerchantCardList);
+// @ts-ignore
+export const openMerchantCard = promisify(my.openMerchantCard);
+// 消息
+export const requestSubscribeMessage = promisify(my.requestSubscribeMessage);
+export const unsubscribeMessage = promisify(my.unsubscribeMessage);
+// 模板配置
+export const getExtConfigSync = my.getExtConfigSync;
+export const getExtConfig = promisify(my.getExtConfig);
+// 支付宝卡包 - 劵
+export const openVoucherList = promisify(my.openVoucherList);
+export const openMerchantVoucherList = promisify(my.openMerchantVoucherList);
+export const openVoucherDetail = promisify(my.openVoucherDetail);
+export const openKBVoucherDetail = promisify(my.openKBVoucherDetail);
+// 支付宝卡包 - 票
+export const openTicketList = promisify(my.openTicketList);
+export const openMerchantTicketList = promisify(my.openMerchantTicketList);
+export const openTicketDetail = promisify(my.openTicketDetail);
+// 交易组件
+export const checkBeforeAddOrder = promisify(my.checkBeforeAddOrder);
+// 小程序商品
+export const prepareUseCertificate = promisify(my.ap.prepareUseCertificate);

--- a/packages/rsmax-ali/src/api.ts
+++ b/packages/rsmax-ali/src/api.ts
@@ -92,7 +92,7 @@ export const regionPicker = promisify(my.regionPicker);
 // 界面 - 选择日期
 export const datePicker = promisify(my.datePicker);
 // 界面 - 动画
-export const createAnimation = promisify(my.createAnimation);
+export const createAnimation = my.createAnimation;
 // 界面 - 地图
 export const getMapInfo = promisify(my.getMapInfo);
 export const createMapContext = my.createMapContext;
@@ -210,8 +210,8 @@ export const getAppBaseInfo = my.getAppBaseInfo;
 export const getAppAuthorizeSetting = my.getAppAuthorizeSetting;
 // 设备 - 网络状态
 export const getNetworkType = promisify(my.getNetworkType);
-export const onNetworkStatusChange = promisify(my.onNetworkStatusChange);
-export const offNetworkStatusChange = promisify(my.offNetworkStatusChange);
+export const onNetworkStatusChange = my.onNetworkStatusChange;
+export const offNetworkStatusChange = my.offNetworkStatusChange;
 // 设备 - 截屏
 export const setVisualEffectOnCapture = promisify(my.setVisualEffectOnCapture);
 // 设备 - 剪贴板
@@ -355,9 +355,9 @@ export const onNeedPrivacyAuthorization = my.onNeedPrivacyAuthorization;
 // @ts-ignore
 export const getPrivacySetting = promisify(my.getPrivacySetting);
 // 小程序广告
-export const createRewardedAd = promisify(my.createRewardedAd);
+export const createRewardedAd = my.createRewardedAd;
 // @ts-ignore
-export const createInterstitialAd = promisify(my.createInterstitialAd);
+export const createInterstitialAd = my.createInterstitialAd;
 /**
  * 开放能力 API
  */

--- a/packages/rsmax-ali/src/index.ts
+++ b/packages/rsmax-ali/src/index.ts
@@ -1,2 +1,3 @@
-export * as component from './hostComponents';
-export * as type from './types';
+export * from './hostComponents';
+export * from './types';
+export * from './api';

--- a/packages/rsmax-cli/src/__tests__/integration/fixtures/wechat-include/src/pages/index.js
+++ b/packages/rsmax-cli/src/__tests__/integration/fixtures/wechat-include/src/pages/index.js
@@ -1,4 +1,4 @@
-import { View } from '@rsmax/wechat/component';
+import { View } from '@rsmax/wechat';
 import Foo from './foo/index';
 
 export default function Index() {

--- a/packages/rsmax-toutiao/package.json
+++ b/packages/rsmax-toutiao/package.json
@@ -7,23 +7,6 @@
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
   "typings": "./esm/index.d.ts",
-  "exports": {
-    "./types": {
-      "types": "./esm/types/index.d.ts",
-      "import": "./esm/types/index.js",
-      "require": "./cjs/types/index.js"
-    },
-    "./component": {
-      "types": "./esm/hostComponents/index.d.ts",
-      "import": "./esm/hostComponents/index.js",
-      "require": "./cjs/hostComponents/index.js"
-    },
-    "./node": {
-      "types": "./esm/node/index.d.ts",
-      "import": "./esm/node/index.js",
-      "require": "./cjs/node/index.js"
-    }
-  },
   "scripts": {
     "prebuild": "npm run clean",
     "build": "tsc",

--- a/packages/rsmax-toutiao/src/api/index.ts
+++ b/packages/rsmax-toutiao/src/api/index.ts
@@ -1,0 +1,344 @@
+import { promisify } from '@rsmax/framework-shared';
+
+// 基础
+export const canIUse = tt.canIUse;
+export const canIPutStuffOverComponent = tt.canIPutStuffOverComponent;
+export const base64ToArrayBuffer = tt.base64ToArrayBuffer;
+export const arrayBufferToBase64 = tt.arrayBufferToBase64;
+// @ts-expect-error
+export const setPageInfo = promisify(tt.setPageInfo);
+// 基础 - 性能
+export const performance = tt.performance;
+// 基础 - 线程
+export const createWorker = tt.createWorker;
+// 基础 - 窗口尺寸变化
+export const offWindowResize = tt.offWindowResize;
+export const onWindowResize = tt.onWindowResize;
+// 基础 - 声明周期
+// @ts-expect-error
+export const getEnterOptionsSync = tt.getEnterOptionsSync;
+export const getLaunchOptionsSync = tt.getLaunchOptionsSync;
+export const exitMiniProgram = tt.exitMiniProgram;
+// 基础 - 版本更新
+export const getUpdateManager = tt.getUpdateManager;
+// 基础 - 应用级事件
+export const onAppShow = tt.onAppShow;
+export const offAppShow = tt.offAppShow;
+export const onAppHide = tt.onAppHide;
+export const offAppHide = tt.offAppHide;
+export const offUnhandledRejection = tt.offUnhandledRejection;
+export const onError = tt.onError;
+export const offError = tt.offError;
+export const onLazyLoadError = tt.onLazyLoadError;
+export const offLazyLoadError = tt.offLazyLoadError;
+export const onUnhandledRejection = tt.onUnhandledRejection;
+// @ts-expect-error
+export const onAppLaunch = tt.onAppLaunch;
+// @ts-expect-error
+export const offAppLaunch = tt.offAppLaunch;
+// 环境变量
+export const env = tt.env;
+export const getEnvInfoSync = tt.getEnvInfoSync;
+// TTML
+export const createSelectorQuery = tt.createSelectorQuery;
+export const createIntersectionObserver = tt.createIntersectionObserver;
+// @ts-expect-error
+export const matchMedia = tt.matchMedia;
+// 网络 - HTTP
+export const request = promisify(tt.request);
+export const downloadFile = promisify(tt.downloadFile);
+export const uploadFile = promisify(tt.uploadFile);
+// 网络 - WebSocket
+export const connectSocket = tt.connectSocket;
+// 网络 - EventSource
+// @ts-expect-error
+export const createEventSource = tt.createEventSource;
+// 媒体 - 图片
+export const chooseImage = promisify(tt.chooseImage);
+export const saveImageToPhotosAlbum = promisify(tt.saveImageToPhotosAlbum);
+export const previewImage = promisify(tt.previewImage);
+export const getImageInfo = promisify(tt.getImageInfo);
+export const compressImage = promisify(tt.compressImage);
+// 媒体 - 录音
+export const getRecorderManager = tt.getRecorderManager;
+// 媒体 - 音频
+export const getBackgroundAudioManager = tt.getBackgroundAudioManager;
+export const createInnerAudioContext = tt.createInnerAudioContext;
+// 媒体 - 视频
+// @ts-expect-error
+export const chooseVideo = promisify(tt.chooseVideo);
+// @ts-expect-error
+export const saveVideoToPhotosAlbum = promisify(tt.saveVideoToPhotosAlbum);
+// @ts-expect-error
+export const canIUseVideoFormat = promisify(tt.canIUseVideoFormat);
+export const prerenderVideo = promisify(tt.prerenderVideo);
+// @ts-expect-error
+export const preloadVideo = promisify(tt.preloadVideo);
+export const chooseMedia = promisify(tt.chooseMedia);
+export const createVideoContext = tt.createVideoContext;
+export const createLivePlayerContext = tt.createLivePlayerContext;
+// 媒体 - 相机
+// @ts-expect-error
+export const createCameraContext = tt.createCameraContext;
+// 媒体 - 特效相机
+// @ts-expect-error
+export const createEffectCameraStream = tt.createEffectCameraStream;
+// 媒体 - Canvas 录制
+// @ts-expect-error
+export const createMediaRecorder = tt.createMediaRecorder;
+// 媒体 -  rtc-room 实时通信
+// @ts-expect-error
+export const createRtcRoomContext = tt.createRtcRoomContext;
+// 地图
+export const createMapContext = tt.createMapContext;
+// 文件
+export const saveFile = promisify(tt.saveFile);
+export const getFileInfo = tt.getFileInfo;
+// @ts-expect-error
+export const openDocument = promisify(tt.openDocument);
+export const getSavedFileList = tt.getSavedFileList;
+export const removeSavedFile = promisify(tt.removeSavedFile);
+export const getFileSystemManager = tt.getFileSystemManager;
+// 文件缓存
+export const getStorage = promisify(tt.getStorage);
+export const getStorageSync = tt.getStorageSync;
+export const setStorage = promisify(tt.setStorage);
+export const setStorageSync = tt.setStorageSync;
+export const removeStorage = promisify(tt.removeStorage);
+export const removeStorageSync = tt.removeStorageSync;
+export const clearStorage = promisify(tt.clearStorage);
+export const clearStorageSync = tt.clearStorageSync;
+export const getStorageInfo = promisify(tt.getStorageInfo);
+export const getStorageInfoSync = tt.getStorageInfoSync;
+// 地理位置
+export const getLocation = promisify(tt.getLocation);
+export const chooseLocation = promisify(tt.chooseLocation);
+export const openLocation = promisify(tt.openLocation);
+// @ts-expect-error
+export const startLocationUpdate = promisify(tt.startLocationUpdate);
+// @ts-expect-error
+export const stopLocationUpdate = promisify(tt.stopLocationUpdate);
+// @ts-expect-error
+export const onLocationChange = tt.onLocationChange;
+// @ts-expect-error
+export const offLocationChange = tt.offLocationChange;
+// @ts-expect-error
+export const onLocationChangeError = tt.onLocationChangeError;
+// @ts-expect-error
+export const offLocationChangeError = tt.offLocationChangeError;
+// 设备 - 网络状态
+// @ts-expect-error
+export const getNetworkType = promisify(tt.getNetworkType);
+export const onNetworkStatusChange = tt.onNetworkStatusChange;
+export const offNetworkStatusChange = tt.offNetworkStatusChange;
+export const getWifiList = promisify(tt.getWifiList);
+export const onGetWifiList = tt.onGetWifiList;
+// @ts-expect-error
+export const onNetworkWeakChange = tt.onNetworkWeakChange;
+// 设备 - 系统信息
+export const getSystemInfo = promisify(tt.getSystemInfo);
+// @ts-expect-error
+export const getDeviceInfoSync = tt.getDeviceInfoSync;
+export const getSystemInfoSync = tt.getSystemInfoSync;
+// 设备 - WIFI
+export const getConnectedWifi = promisify(tt.getConnectedWifi);
+// 设备 - 加速度计
+export const startAccelerometer = promisify(tt.startAccelerometer);
+export const stopAccelerometer = promisify(tt.stopAccelerometer);
+export const onAccelerometerChange = tt.onAccelerometerChange;
+// @ts-expect-error
+export const offAccelerometerChange = tt.offAccelerometerChange;
+// 设备 - 罗盘
+export const startCompass = promisify(tt.startCompass);
+export const stopCompass = promisify(tt.stopCompass);
+export const onCompassChange = tt.onCompassChange;
+export const offCompassChange = tt.offCompassChange;
+// 设备 - 拨打电话
+export const makePhoneCall = promisify(tt.makePhoneCall);
+// 设备 - 扫码
+export const scanCode = promisify(tt.scanCode);
+// 设备 - 剪切板
+export const getClipboardData = promisify(tt.getClipboardData);
+export const setClipboardData = promisify(tt.setClipboardData);
+// 设备 - 屏幕
+export const setKeepScreenOn = promisify(tt.setKeepScreenOn);
+export const onUserCaptureScreen = tt.onUserCaptureScreen;
+export const offUserCaptureScreen = tt.offUserCaptureScreen;
+export const getScreenBrightness = tt.getScreenBrightness;
+export const setScreenBrightness = promisify(tt.setScreenBrightness);
+// @ts-expect-error
+export const onUserScreenRecord = tt.onUserScreenRecord;
+// @ts-expect-error
+export const offUserScreenRecord = tt.offUserScreenRecord;
+// @ts-expect-error
+export const enableUserScreenRecord = promisify(tt.enableUserScreenRecord);
+// @ts-expect-error
+export const disableUserScreenRecord = promisify(tt.disableUserScreenRecord);
+// 设备 - 陀螺仪
+// @ts-expect-error
+export const startGyroscope = promisify(tt.startGyroscope);
+// @ts-expect-error
+export const stopGyroscope = promisify(tt.stopGyroscope);
+// @ts-expect-error
+export const onGyroscopeChange = tt.onGyroscopeChange;
+// @ts-expect-error
+export const offGyroscopeChange = tt.offGyroscopeChange;
+// 设备 - 加密
+// @ts-expect-error
+export const getRandomValues = promisify(tt.getRandomValues);
+// 设备 - 短信
+// @ts-expect-error
+export const sendSms = promisify(tt.sendSms);
+// 设备 - 日历
+// @ts-expect-error
+export const deleteCalendarEvent = promisify(tt.deleteCalendarEvent);
+// 设备 - 振动
+export const vibrateShort = promisify(tt.vibrateShort);
+export const vibrateLong = promisify(tt.vibrateLong);
+// 设备 - 性能
+export const onMemoryWarning = tt.onMemoryWarning;
+// 画布 v1
+export const createCanvasContext = tt.createCanvasContext;
+export const canvasToTempFilePath = tt.canvasToTempFilePath;
+// 画布 v2
+export const createOffscreenCanvas = tt.createOffscreenCanvas;
+// 界面 - 交互反馈
+// @ts-expect-error
+export const enableAlertBeforeUnload = promisify(tt.enableAlertBeforeUnload);
+export const showToast = promisify(tt.showToast);
+export const showLoading = promisify(tt.showLoading);
+export const hideToast = promisify(tt.hideToast);
+export const hideLoading = promisify(tt.hideLoading);
+export const showModal = promisify(tt.showModal);
+// @ts-expect-error
+export const showActionSheet = promisify(tt.showActionSheet);
+export const showFavoriteGuide = promisify(tt.showFavoriteGuide);
+export const showInteractionBar = promisify(tt.showInteractionBar);
+export const hideInteractionBar = promisify(tt.hideInteractionBar);
+// @ts-expect-error
+export const disableAlertBeforeUnload = promisify(tt.disableAlertBeforeUnload);
+// 界面 - 导航栏
+export const showNavigationBarLoading = promisify(tt.showNavigationBarLoading);
+export const hideNavigationBarLoading = promisify(tt.hideNavigationBarLoading);
+export const hideHomeButton = promisify(tt.hideHomeButton);
+export const setNavigationBarTitle = promisify(tt.setNavigationBarTitle);
+export const setNavigationBarColor = promisify(tt.setNavigationBarColor);
+// 界面 - 菜单
+// @ts-expect-error
+export const getCustomButtonBoundingClientRect = tt.getCustomButtonBoundingClientRect;
+export const getMenuButtonBoundingClientRect = tt.getMenuButtonBoundingClientRect;
+// 界面 - 动画
+export const createAnimation = tt.createAnimation;
+// 界面 - 页面位置
+export const pageScrollTo = promisify(tt.pageScrollTo);
+// 界面 - 滑动返回
+// @ts-expect-error
+export const setSwipeBackMode = tt.setSwipeBackMode;
+// 界面 - 下拉刷新
+export const startPullDownRefresh = tt.startPullDownRefresh;
+export const stopPullDownRefresh = tt.stopPullDownRefresh;
+// 界面 - 键盘
+export const hideKeyboard = promisify(tt.hideKeyboard);
+// 界面  - tab bar
+export const showTabBarRedDot = promisify(tt.showTabBarRedDot);
+export const showTabBar = promisify(tt.showTabBar);
+export const setTabBarStyle = promisify(tt.setTabBarStyle);
+export const setTabBarItem = promisify(tt.setTabBarItem);
+export const setTabBarBadge = promisify(tt.setTabBarBadge);
+export const removeTabBarBadge = promisify(tt.removeTabBarBadge);
+export const hideTabBarRedDot = promisify(tt.hideTabBarRedDot);
+export const hideTabBar = promisify(tt.hideTabBar);
+// 页面导航
+export const navigateTo = promisify(tt.navigateTo);
+export const redirectTo = promisify(tt.redirectTo);
+export const switchTab = promisify(tt.switchTab);
+export const navigateBack = promisify(tt.navigateBack);
+export const reLaunch = promisify(tt.reLaunch);
+// 开放接口 - 登录
+export const login = promisify(tt.login);
+export const checkSession = tt.checkSession;
+// 开放接口 - 用户信息
+export const getUserInfo = promisify(tt.getUserInfo);
+export const getUserProfile = promisify(tt.getUserProfile);
+// 开放接口 - 广告
+// @ts-expect-error
+export const createRewardedVideoAd = tt.createRewardedVideoAd;
+export const createInterstitialAd = tt.createInterstitialAd;
+// @ts-expect-error
+export const preloadDrawAd = promisify(tt.preloadDrawAd);
+// 开放接口 - 支付
+export const pay = promisify(tt.pay);
+// 开放接口 - 小程序跳转
+export const navigateToMiniProgram = promisify(tt.navigateToMiniProgram);
+export const navigateBackMiniProgram = promisify(tt.navigateBackMiniProgram);
+// 开放接口 - 收货地址
+export const chooseAddress = promisify(tt.chooseAddress);
+// 开放接口 - 设置
+export const getSetting = promisify(tt.getSetting);
+export const openSetting = promisify(tt.openSetting);
+// 开放接口 - 授权
+export const authorize = promisify(tt.authorize);
+export const showDouyinOpenAuth = promisify(tt.showDouyinOpenAuth);
+// 开放接口 - 评价能力
+// @ts-expect-error
+export const rateAwemeOrder = tt.rateAwemeOrder;
+// @ts-expect-error
+export const canRateAwemeOrders = promisify(tt.canRateAwemeOrders);
+// 开放接口 - 数据分析
+export const reportAnalytics = tt.reportAnalytics;
+// 开放接口 - 引导关注
+export const followOfficialAccount = promisify(tt.followOfficialAccount);
+export const openAwemeUserProfile = promisify(tt.openAwemeUserProfile);
+export const checkFollowState = promisify(tt.checkFollowState);
+export const followAwemeUser = promisify(tt.followAwemeUser);
+// @ts-expect-error
+export const checkFollowAwemeState = promisify(tt.checkFollowAwemeState);
+// 开放接口 - 订阅消息
+export const requestSubscribeMessage = promisify(tt.requestSubscribeMessage);
+// 开放接口 - 流量来源识别
+export const getAnalysisInfo = promisify(tt.getAnalysisInfo);
+// 开放接口 - 隐私信息授权
+// @ts-expect-error
+export const requirePrivacyAuthorize = promisify(tt.requirePrivacyAuthorize);
+// @ts-expect-error
+export const openPrivacyContract = promisify(tt.openPrivacyContract);
+// @ts-expect-error
+export const onNeedPrivacyAuthorization = tt.onNeedPrivacyAuthorization;
+// @ts-expect-error
+export const getPrivacySetting = promisify(tt.getPrivacySetting);
+// 开放接口 - web 化
+// 开放接口 -  转发和挂载
+export const showShareMenu = promisify(tt.showShareMenu);
+export const hideShareMenu = promisify(tt.hideShareMenu);
+export const navigateToVideoView = promisify(tt.navigateToVideoView);
+// 开放接口 -  侧边栏能力
+export const getSidebarActivity = promisify(tt.getSidebarActivity);
+export const navigateToScene = promisify(tt.navigateToScene);
+export const updateSidebarActivity = promisify(tt.updateSidebarActivity);
+// @ts-expect-error
+export const createSceneActivityContext = tt.createSceneActivityContext;
+// 开发接口 - AI/AR能力
+// @ts-expect-error
+export const getAlgorithmManager = promisify(tt.getAlgorithmManager);
+// @ts-expect-error
+export const createBytennEngineContext = tt.createBytennEngineContext;
+// @ts-expect-error
+export const createStickerManager = tt.createStickerManager;
+// 开发接口 - 安全能力
+// @ts-expect-error
+export const getLatestUserCryptoKey = promisify(tt.getLatestUserCryptoKey);
+// 行业开放 - 通用交易系统
+// @ts-expect-error
+export const requestOrder = promisify(tt.requestOrder);
+// @ts-expect-error
+export const getOrderPayment = promisify(tt.getOrderPayment);
+// @ts-expect-error
+export const confirmFulfillment = tt.confirmFulfillment;
+// 行业开放 - 交易工具
+// @ts-expect-error
+export const createSignOrder = tt.createSignOrder;
+// @ts-expect-error
+export const sign = tt.sign;
+// 第三方平台
+export const getExtConfig = promisify(tt.getExtConfig);
+export const getExtConfigSync = tt.getExtConfigSync;

--- a/packages/rsmax-toutiao/src/index.ts
+++ b/packages/rsmax-toutiao/src/index.ts
@@ -1,2 +1,3 @@
-export * as component from './hostComponents';
-export * as type from './types';
+export * from './hostComponents';
+export * from './api';
+export * from './types';

--- a/packages/rsmax-wechat/package.json
+++ b/packages/rsmax-wechat/package.json
@@ -29,36 +29,6 @@
     "react-test-renderer": "^18.3.0"
   },
   "sideEffects": false,
-  "exports": {
-    "./types": {
-      "types": "./esm/types/index.d.ts",
-      "import": "./esm/types/index.js",
-      "require": "./cjs/types/index.js"
-    },
-    "./component": {
-      "types": "./esm/hostComponents/index.d.ts",
-      "import": "./esm/hostComponents/index.js",
-      "require": "./cjs/hostComponents/index.js"
-    },
-    "./node": {
-      "types": "./esm/node/index.d.ts",
-      "import": "./esm/node/index.js",
-      "require": "./cjs/node/index.js"
-    }
-  },
-  "typesVersions": {
-    "*": {
-      "types": [
-        "esm/types/index.d.ts"
-      ],
-      "component": [
-        "esm/hostComponents/index.d.ts"
-      ],
-      "node": [
-        "esm/node/index.d.ts"
-      ]
-    }
-  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/rsmax-wechat/src/api/index.ts
+++ b/packages/rsmax-wechat/src/api/index.ts
@@ -215,10 +215,10 @@ export const createGlobalPayment = wx.createGlobalPayment;
 export const setStorageSync = wx.setStorageSync;
 export const setStorage = promisify(wx.setStorage);
 export const revokeBufferURL = wx.revokeBufferURL;
-export const removeStorageSync = promisify(wx.removeStorageSync);
+export const removeStorageSync = wx.removeStorageSync;
 export const removeStorage = promisify(wx.removeStorage);
 export const getStorageSync = wx.getStorageSync;
-export const getStorageInfoSync = promisify(wx.getStorageInfoSync);
+export const getStorageInfoSync = wx.getStorageInfoSync;
 export const getStorageInfo = promisify(wx.getStorageInfo);
 export const getStorage = promisify(wx.getStorage);
 export const createBufferURL = wx.createBufferURL;
@@ -341,7 +341,7 @@ export const chooseLocation = promisify(wx.chooseLocation);
 // 文件
 export const saveFileToDisk = wx.saveFileToDisk;
 export const openDocument = promisify(wx.openDocument);
-export const getFileSystemManager = promisify(wx.getFileSystemManager);
+export const getFileSystemManager = wx.getFileSystemManager;
 // 开放接口 - 登录
 export const pluginLogin = wx.pluginLogin;
 export const login = wx.login;
@@ -446,7 +446,7 @@ export const closeBLEConnection = promisify(wx.closeBLEConnection);
 // 设备 - 蓝牙 - 低功耗外围设备
 export const onBLEPeripheralConnectionStateChanged = wx.onBLEPeripheralConnectionStateChanged;
 export const offBLEPeripheralConnectionStateChanged = wx.offBLEPeripheralConnectionStateChanged;
-export const createBLEPeripheralServer = promisify(wx.createBLEPeripheralServer);
+export const createBLEPeripheralServer = wx.createBLEPeripheralServer;
 // 设备 - 蓝牙 - 信标
 export const stopBeaconDiscovery = promisify(wx.stopBeaconDiscovery);
 export const startBeaconDiscovery = promisify(wx.startBeaconDiscovery);
@@ -480,7 +480,7 @@ export const checkIsOpenAccessibility = promisify(wx.checkIsOpenAccessibility);
 // 设备 - 电量
 export const onBatteryInfoChange = wx.onBatteryInfoChange;
 export const offBatteryInfoChange = wx.offBatteryInfoChange;
-export const getBatteryInfoSync = promisify(wx.getBatteryInfoSync);
+export const getBatteryInfoSync = wx.getBatteryInfoSync;
 export const getBatteryInfo = promisify(wx.getBatteryInfo);
 // 设备 - 剪贴板
 export const setClipboardData = promisify(wx.setClipboardData);

--- a/packages/rsmax-wechat/src/api/index.ts
+++ b/packages/rsmax-wechat/src/api/index.ts
@@ -1,0 +1,575 @@
+import { promisify } from '@rsmax/framework-shared';
+
+// 基础
+export const env = wx.env;
+export const canIUse = wx.canIUse;
+export const base64ToArrayBuffer = wx.base64ToArrayBuffer;
+export const arrayBufferToBase64 = wx.arrayBufferToBase64;
+export const getLaunchOptionsSync = wx.getLaunchOptionsSync;
+export const cloud = wx.cloud;
+// 基础 - 系统
+export const openSystemBluetoothSetting = promisify(wx.openSystemBluetoothSetting);
+export const openAppAuthorizeSetting = promisify(wx.openAppAuthorizeSetting);
+export const getWindowInfo = wx.getWindowInfo;
+export const getSystemSetting = wx.getSystemSetting;
+export const getSystemInfoSync = wx.getSystemInfoSync;
+export const getSystemInfoAsync = wx.getSystemInfoAsync;
+export const getSystemInfo = promisify(wx.getSystemInfo);
+export const getSkylineInfoSync = wx.getSkylineInfoSync;
+export const getSkylineInfo = wx.getSkylineInfo;
+export const getRendererUserAgent = wx.getRendererUserAgent;
+export const getDeviceInfo = wx.getDeviceInfo;
+export const getDeviceBenchmarkInfo = wx.getDeviceBenchmarkInfo;
+export const getAppBaseInfo = wx.getAppBaseInfo;
+export const getAppAuthorizeSetting = wx.getAppAuthorizeSetting;
+// 基础 - 更新
+export const updateWeChatApp = promisify(wx.updateWeChatApp);
+export const getUpdateManager = wx.getUpdateManager;
+// 基础 - 小程序 - 生命周期
+export const onApiCategoryChange = wx.onApiCategoryChange;
+export const offApiCategoryChange = wx.offApiCategoryChange;
+export const getEnterOptionsSync = wx.getEnterOptionsSync;
+// 基础 - 小程序 - 应用级事件
+export const postMessageToReferrerPage = wx.postMessageToReferrerPage;
+export const postMessageToReferrerMiniProgram = wx.postMessageToReferrerMiniProgram;
+export const onUnhandledRejection = wx.onUnhandledRejection;
+export const onThemeChange = wx.onThemeChange;
+export const onPageNotFound = wx.onPageNotFound;
+export const onLazyLoadError = wx.onLazyLoadError;
+export const onError = wx.onError;
+export const onAudioInterruptionEnd = wx.onAudioInterruptionEnd;
+export const onAudioInterruptionBegin = wx.onAudioInterruptionBegin;
+export const onAppShow = wx.onAppShow;
+export const onAppHide = wx.onAppHide;
+export const offUnhandledRejection = wx.offUnhandledRejection;
+export const offThemeChange = wx.offThemeChange;
+export const offPageNotFound = wx.offPageNotFound;
+export const offLazyLoadError = wx.offLazyLoadError;
+export const offError = wx.offError;
+export const offAudioInterruptionEnd = wx.offAudioInterruptionEnd;
+export const offAudioInterruptionBegin = wx.offAudioInterruptionBegin;
+export const offAppShow = wx.offAppShow;
+export const offAppHide = wx.offAppHide;
+// 基础 - 小程序 - 路由事件
+export const onBeforePageUnload = wx.onBeforePageUnload;
+export const onBeforePageLoad = wx.onBeforePageLoad;
+export const onBeforeAppRoute = wx.onBeforeAppRoute;
+export const onAppRouteDone = wx.onAppRouteDone;
+export const onAppRoute = wx.onAppRoute;
+export const onAfterPageUnload = wx.onAfterPageUnload;
+export const onAfterPageLoad = wx.onAfterPageLoad;
+export const offBeforePageUnload = wx.offBeforePageUnload;
+export const offBeforePageLoad = wx.offBeforePageLoad;
+export const offBeforeAppRoute = wx.offBeforeAppRoute;
+export const offAppRouteDone = wx.offAppRouteDone;
+export const offAppRoute = wx.offAppRoute;
+export const offAfterPageUnload = wx.offAfterPageUnload;
+export const offAfterPageLoad = wx.offAfterPageLoad;
+// 基础 - 调试
+export const setEnableDebug = promisify(wx.setEnableDebug);
+export const getRealtimeLogManager = wx.getRealtimeLogManager;
+export const getLogManager = wx.getLogManager;
+// 基础 - 性能
+export const reportPerformance = wx.reportPerformance;
+export const preloadWebview = wx.preloadWebview;
+export const preloadSkylineView = wx.preloadSkylineView;
+export const preloadAssets = wx.preloadAssets;
+export const getPerformance = wx.getPerformance;
+// 基础 - 分包加载
+export const preDownloadSubpackage = wx.preDownloadSubpackage;
+// 基础 - 加密
+export const getUserCryptoManager = wx.getUserCryptoManager;
+// 路由
+export const switchTab = promisify(wx.switchTab);
+export const rewriteRoute = wx.rewriteRoute;
+export const reLaunch = promisify(wx.reLaunch);
+export const redirectTo = promisify(wx.redirectTo);
+export const navigateTo = promisify(wx.navigateTo);
+export const navigateBack = promisify(wx.navigateBack);
+// 自定义路由
+export const router = wx.router;
+// 跳转
+export const restartMiniProgram = wx.restartMiniProgram;
+export const openOfficialAccountProfile = wx.openOfficialAccountProfile;
+export const openOfficialAccountArticle = wx.openOfficialAccountArticle;
+export const openEmbeddedMiniProgram = promisify(wx.openEmbeddedMiniProgram);
+export const onEmbeddedMiniProgramHeightChange = wx.onEmbeddedMiniProgramHeightChange;
+export const offEmbeddedMiniProgramHeightChange = wx.offEmbeddedMiniProgramHeightChange;
+export const navigateToMiniProgram = promisify(wx.navigateToMiniProgram);
+export const navigateBackMiniProgram = promisify(wx.navigateBackMiniProgram);
+export const exitMiniProgram = promisify(wx.exitMiniProgram);
+// 聊天工具
+export const shareVideoToGroup = promisify(wx.shareVideoToGroup);
+export const shareImageToGroup = promisify(wx.shareImageToGroup);
+export const shareFileToGroup = promisify(wx.shareFileToGroup);
+export const shareEmojiToGroup = promisify(wx.shareEmojiToGroup);
+export const shareAppMessageToGroup = promisify(wx.shareAppMessageToGroup);
+export const selectGroupMembers = promisify(wx.selectGroupMembers);
+export const openChatTool = promisify(wx.openChatTool);
+export const notifyGroupMembers = promisify(wx.notifyGroupMembers);
+export const getChatToolInfo = promisify(wx.getChatToolInfo);
+// 转发
+export const updateShareMenu = promisify(wx.updateShareMenu);
+export const showShareMenu = promisify(wx.showShareMenu);
+export const showShareImageMenu = promisify(wx.showShareImageMenu);
+export const shareVideoMessage = promisify(wx.shareVideoMessage);
+export const shareFileMessage = promisify(wx.shareFileMessage);
+export const onCopyUrl = wx.onCopyUrl;
+export const offCopyUrl = wx.offCopyUrl;
+export const hideShareMenu = promisify(wx.hideShareMenu);
+export const getShareInfo = wx.getShareInfo;
+export const authPrivateMessage = promisify(wx.authPrivateMessage);
+// 界面 - 交互
+export const showToast = promisify(wx.showToast);
+export const showModal = promisify(wx.showModal);
+export const showLoading = promisify(wx.showLoading);
+export const showActionSheet = promisify(wx.showActionSheet);
+export const hideToast = promisify(wx.hideToast);
+export const hideLoading = promisify(wx.hideLoading);
+export const enableAlertBeforeUnload = wx.enableAlertBeforeUnload;
+export const disableAlertBeforeUnload = wx.disableAlertBeforeUnload;
+// 界面 - 导航栏
+export const showNavigationBarLoading = promisify(wx.showNavigationBarLoading);
+export const setNavigationBarTitle = promisify(wx.setNavigationBarTitle);
+export const setNavigationBarColor = promisify(wx.setNavigationBarColor);
+export const hideNavigationBarLoading = promisify(wx.hideNavigationBarLoading);
+export const hideHomeButton = promisify(wx.hideHomeButton);
+// 界面 - 背景
+export const setBackgroundTextStyle = promisify(wx.setBackgroundTextStyle);
+export const setBackgroundColor = promisify(wx.setBackgroundColor);
+// 界面 - tab bar
+export const showTabBarRedDot = promisify(wx.showTabBarRedDot);
+export const showTabBar = promisify(wx.showTabBar);
+export const setTabBarStyle = promisify(wx.setTabBarStyle);
+export const setTabBarItem = promisify(wx.setTabBarItem);
+export const setTabBarBadge = promisify(wx.setTabBarBadge);
+export const removeTabBarBadge = promisify(wx.removeTabBarBadge);
+export const hideTabBarRedDot = promisify(wx.hideTabBarRedDot);
+export const hideTabBar = promisify(wx.hideTabBar);
+// 界面 - 字体
+export const loadFontFace = promisify(wx.loadFontFace);
+export const loadBuiltInFontFace = wx.loadBuiltInFontFace;
+// 界面 - 下拉刷新
+export const stopPullDownRefresh = promisify(wx.stopPullDownRefresh);
+export const startPullDownRefresh = promisify(wx.startPullDownRefresh);
+// 界面 - 滚动
+export const pageScrollTo = promisify(wx.pageScrollTo);
+// 界面 - 动画
+export const createAnimation = wx.createAnimation;
+// 界面 - 置顶
+// 基础库 1.9.9 开始，本接口停止维护
+export const setTopBarText = promisify(wx.setTopBarText);
+// 界面 - 自定义组件
+export const nextTick = wx.nextTick;
+// 界面 - 菜单
+export const onOnUserTriggerTranslation = wx.onOnUserTriggerTranslation;
+export const onMenuButtonBoundingClientRectWeightChange = wx.onMenuButtonBoundingClientRectWeightChange;
+export const offOnUserTriggerTranslation = wx.offOnUserTriggerTranslation;
+export const offMenuButtonBoundingClientRectWeightChange = wx.offMenuButtonBoundingClientRectWeightChange;
+export const getMenuButtonBoundingClientRect = wx.getMenuButtonBoundingClientRect;
+// 界面 - 窗口
+// 从基础库 2.11.0 开始，本接口停止维护
+export const setWindowSize = wx.setWindowSize;
+export const onWindowResize = wx.onWindowResize;
+export const offWindowResize = wx.offWindowResize;
+export const checkIsPictureInPictureActive = wx.checkIsPictureInPictureActive;
+// 界面 - worklet 动画
+export const worklet = wx.worklet;
+// 网络
+export const request = wx.request;
+export const downloadFile = wx.downloadFile;
+export const uploadFile = wx.uploadFile;
+// websocket
+export const sendSocketMessage = promisify(wx.sendSocketMessage);
+export const onSocketOpen = wx.onSocketOpen;
+export const onSocketMessage = wx.onSocketMessage;
+export const onSocketError = wx.onSocketError;
+export const onSocketClose = wx.onSocketClose;
+export const connectSocket = wx.connectSocket;
+export const closeSocket = promisify(wx.closeSocket);
+// mDNS
+export const stopLocalServiceDiscovery = promisify(wx.stopLocalServiceDiscovery);
+export const startLocalServiceDiscovery = promisify(wx.startLocalServiceDiscovery);
+export const onLocalServiceResolveFail = wx.onLocalServiceResolveFail;
+export const onLocalServiceLost = wx.onLocalServiceLost;
+export const onLocalServiceFound = wx.onLocalServiceFound;
+export const onLocalServiceDiscoveryStop = wx.onLocalServiceDiscoveryStop;
+export const offLocalServiceResolveFail = wx.offLocalServiceResolveFail;
+export const offLocalServiceLost = wx.offLocalServiceLost;
+export const offLocalServiceFound = wx.offLocalServiceFound;
+export const offLocalServiceDiscoveryStop = wx.offLocalServiceDiscoveryStop;
+// TCP 通信
+export const createTCPSocket = wx.createTCPSocket;
+// UDP 通信
+export const createUDPSocket = wx.createUDPSocket;
+// 支付
+export const requestVirtualPayment = wx.requestVirtualPayment;
+export const requestPluginPayment = wx.requestPluginPayment;
+export const requestPayment = promisify(wx.requestPayment);
+export const requestMerchantTransfer = wx.requestMerchantTransfer;
+export const requestCommonPayment = wx.requestCommonPayment;
+export const openHKOfflinePayView = wx.openHKOfflinePayView;
+// 全球支付
+export const createGlobalPayment = wx.createGlobalPayment;
+// 数据缓存
+export const setStorageSync = wx.setStorageSync;
+export const setStorage = promisify(wx.setStorage);
+export const revokeBufferURL = wx.revokeBufferURL;
+export const removeStorageSync = promisify(wx.removeStorageSync);
+export const removeStorage = promisify(wx.removeStorage);
+export const getStorageSync = wx.getStorageSync;
+export const getStorageInfoSync = promisify(wx.getStorageInfoSync);
+export const getStorageInfo = promisify(wx.getStorageInfo);
+export const getStorage = promisify(wx.getStorage);
+export const createBufferURL = wx.createBufferURL;
+export const clearStorageSync = wx.clearStorageSync;
+export const clearStorage = promisify(wx.clearStorage);
+export const batchSetStorageSync = wx.batchSetStorageSync;
+export const batchSetStorage = promisify(wx.batchSetStorage);
+export const batchGetStorageSync = wx.batchGetStorageSync;
+export const batchGetStorage = promisify(wx.batchGetStorage);
+// 数据预拉取和周期性更新
+export const setBackgroundFetchToken = promisify(wx.setBackgroundFetchToken);
+export const onBackgroundFetchData = wx.onBackgroundFetchData;
+export const getBackgroundFetchToken = promisify(wx.getBackgroundFetchToken);
+export const getBackgroundFetchData = promisify(wx.getBackgroundFetchData);
+// 缓存管理器
+export const createCacheManager = wx.createCacheManager;
+// 数据分析
+// 从基础库 2.31.1 开始，本接口停止维护，请使用 wx.reportEvent 代替
+export const reportMonitor = wx.reportMonitor;
+export const reportEvent = wx.reportEvent;
+export const reportAnalytics = wx.reportAnalytics;
+export const getExptInfoSync = wx.getExptInfoSync;
+export const getCommonConfig = wx.getCommonConfig;
+// 画布
+export const createOffscreenCanvas = wx.createOffscreenCanvas;
+// 从基础库 2.9.0 开始，本接口停止维护，请使用 Canvas 代替
+export const createCanvasContext = wx.createCanvasContext;
+export const canvasToTempFilePath = promisify(wx.canvasToTempFilePath);
+export const canvasPutImageData = promisify(wx.canvasPutImageData);
+export const canvasGetImageData = promisify(wx.canvasGetImageData);
+// 媒体 - 地图
+export const createMapContext = wx.createMapContext;
+// 媒体 - 图片
+export const saveImageToPhotosAlbum = promisify(wx.saveImageToPhotosAlbum);
+export const previewMedia = promisify(wx.previewMedia);
+export const previewImage = promisify(wx.previewImage);
+export const getImageInfo = promisify(wx.getImageInfo);
+export const editImage = wx.editImage;
+export const cropImage = wx.cropImage;
+export const compressImage = promisify(wx.compressImage);
+export const chooseMessageFile = promisify(wx.chooseMessageFile);
+// 从基础库 2.21.0 开始，本接口停止维护，请使用 wx.chooseMedia 代替
+export const chooseImage = promisify(wx.chooseImage);
+// 媒体 - 视频
+export const saveVideoToPhotosAlbum = promisify(wx.saveVideoToPhotosAlbum);
+export const openVideoEditor = wx.openVideoEditor;
+export const getVideoInfo = promisify(wx.getVideoInfo);
+export const createVideoContext = wx.createVideoContext;
+export const compressVideo = promisify(wx.compressVideo);
+// 从基础库 2.21.0 开始，本接口停止维护，请使用 wx.chooseMedia 代替
+export const chooseVideo = promisify(wx.chooseVideo);
+export const chooseMedia = promisify(wx.chooseMedia);
+export const checkDeviceSupportHevc = wx.checkDeviceSupportHevc;
+// 媒体 - 音频
+// 从基础库 1.6.0 开始，本接口停止维护，请使用 wx.createInnerAudioContext 代替
+export const stopVoice = promisify(wx.stopVoice);
+export const setInnerAudioOption = promisify(wx.setInnerAudioOption);
+export const playVoice = promisify(wx.playVoice);
+export const pauseVoice = promisify(wx.pauseVoice);
+export const getAvailableAudioSources = promisify(wx.getAvailableAudioSources);
+export const createWebAudioContext = wx.createWebAudioContext;
+export const createInnerAudioContext = wx.createInnerAudioContext;
+// 从基础库 1.6.0 开始，本接口停止维护，请使用 wx.createInnerAudioContext 代替
+export const createAudioContext = wx.createAudioContext;
+export const stopBackgroundAudio = promisify(wx.stopBackgroundAudio);
+export const seekBackgroundAudio = promisify(wx.seekBackgroundAudio);
+export const playBackgroundAudio = promisify(wx.playBackgroundAudio);
+export const pauseBackgroundAudio = promisify(wx.pauseBackgroundAudio);
+export const onBackgroundAudioStop = wx.onBackgroundAudioStop;
+export const onBackgroundAudioPlay = wx.onBackgroundAudioPlay;
+export const onBackgroundAudioPause = wx.onBackgroundAudioPause;
+export const getBackgroundAudioPlayerState = promisify(wx.getBackgroundAudioPlayerState);
+export const getBackgroundAudioManager = wx.getBackgroundAudioManager;
+// 媒体 - 实时音视频
+export const createLivePlayerContext = wx.createLivePlayerContext;
+export const createLivePusherContext = wx.createLivePusherContext;
+// 媒体 - 录音
+// 从基础库 1.6.0 开始，本接口停止维护，请使用 wx.getRecorderManager 代替
+export const stopRecord = promisify(wx.stopRecord);
+export const startRecord = promisify(wx.startRecord);
+export const getRecorderManager = wx.getRecorderManager;
+// 媒体 - 相机
+export const createCameraContext = wx.createCameraContext;
+// 媒体 - 音视频合成
+export const createMediaContainer = wx.createMediaContainer;
+// 媒体 - 实时语音
+export const updateVoIPChatMuteConfig = promisify(wx.updateVoIPChatMuteConfig);
+export const subscribeVoIPVideoMembers = promisify(wx.subscribeVoIPVideoMembers);
+export const setEnable1v1Chat = promisify(wx.setEnable1v1Chat);
+export const onVoIPVideoMembersChanged = wx.onVoIPVideoMembersChanged;
+export const onVoIPChatStateChanged = wx.onVoIPChatStateChanged;
+export const onVoIPChatSpeakersChanged = wx.onVoIPChatSpeakersChanged;
+export const onVoIPChatMembersChanged = wx.onVoIPChatMembersChanged;
+export const onVoIPChatInterrupted = wx.onVoIPChatInterrupted;
+export const offVoIPVideoMembersChanged = wx.offVoIPVideoMembersChanged;
+export const offVoIPChatStateChanged = wx.offVoIPChatStateChanged;
+export const offVoIPChatSpeakersChanged = wx.offVoIPChatSpeakersChanged;
+export const offVoIPChatMembersChanged = wx.offVoIPChatMembersChanged;
+export const offVoIPChatInterrupted = wx.offVoIPChatInterrupted;
+export const joinVoIPChat = promisify(wx.joinVoIPChat);
+export const join1v1Chat = promisify(wx.join1v1Chat);
+export const exitVoIPChat = promisify(wx.exitVoIPChat);
+// 媒体 - 画面录制器
+export const createMediaRecorder = wx.createMediaRecorder;
+// 媒体  - 视频解码器
+export const createVideoDecoder = wx.createVideoDecoder;
+// 位置
+export const stopLocationUpdate = promisify(wx.stopLocationUpdate);
+export const startLocationUpdateBackground = promisify(wx.startLocationUpdateBackground);
+export const startLocationUpdate = promisify(wx.startLocationUpdate);
+export const openLocation = promisify(wx.openLocation);
+export const onLocationChangeError = wx.onLocationChangeError;
+export const offLocationChangeError = wx.offLocationChangeError;
+export const onLocationChange = wx.onLocationChange;
+export const getLocation = promisify(wx.getLocation);
+export const getFuzzyLocation = wx.getFuzzyLocation;
+// 为确保选择地理位置接口的合理使用，位置接口调整参考 选择地理位置接口调整公告
+export const choosePoi = promisify(wx.choosePoi);
+export const chooseLocation = promisify(wx.chooseLocation);
+// 文件
+export const saveFileToDisk = wx.saveFileToDisk;
+export const openDocument = promisify(wx.openDocument);
+export const getFileSystemManager = promisify(wx.getFileSystemManager);
+// 开放接口 - 登录
+export const pluginLogin = wx.pluginLogin;
+export const login = wx.login;
+export const checkSession = promisify(wx.checkSession);
+// 开放接口 - 账号信息
+export const getAccountInfoSync = wx.getAccountInfoSync;
+// 开放接口 - 用户信息 用户头像昵称获取规则已调整 https://developers.weixin.qq.com/community/develop/doc/00022c683e8a80b29bed2142b56c01
+export const getUserProfile = promisify(wx.getUserProfile);
+export const getUserInfo = promisify(wx.getUserInfo);
+// 开放接口 - 授权
+export const authorizeForMiniProgram = wx.authorizeForMiniProgram;
+export const authorize = promisify(wx.authorize);
+// 开放接口 - 设置
+export const openSetting = promisify(wx.openSetting);
+export const getSetting = promisify(wx.getSetting);
+// 开放接口 - 收货地址
+export const chooseAddress = promisify(wx.chooseAddress);
+// 开放接口 - 卡卷
+export const openCard = promisify(wx.openCard);
+export const addCard = promisify(wx.addCard);
+// 开发接口 -  发票
+export const chooseInvoiceTitle = promisify(wx.chooseInvoiceTitle);
+export const chooseInvoice = promisify(wx.chooseInvoice);
+// 开发接口 -  生物认证
+export const startSoterAuthentication = promisify(wx.startSoterAuthentication);
+export const checkIsSupportSoterAuthentication = promisify(wx.checkIsSupportSoterAuthentication);
+export const checkIsSoterEnrolledInDevice = promisify(wx.checkIsSoterEnrolledInDevice);
+// 开放接口 - 微信运动
+export const shareToWeRun = promisify(wx.shareToWeRun);
+export const getWeRunData = promisify(wx.getWeRunData);
+// 开放接口 - 订阅消息
+export const requestSubscribeMessage = promisify(wx.requestSubscribeMessage);
+export const requestSubscribeDeviceMessage = promisify(wx.requestSubscribeDeviceMessage);
+// 开放接口 - 微信红包
+export const showRedPackage = promisify(wx.showRedPackage);
+// 开放接口 - 微信小店
+export const openStoreOrderDetail = wx.openStoreOrderDetail;
+export const openStoreCouponDetail = wx.openStoreCouponDetail;
+// 开放接口 - 收藏
+export const addVideoToFavorites = wx.addVideoToFavorites;
+export const addFileToFavorites = wx.addFileToFavorites;
+// 开放接口 - 我的小程序
+export const checkIsAddedToMyMiniProgram = wx.checkIsAddedToMyMiniProgram;
+// 开放接口 - 车牌
+export const chooseLicensePlate = wx.chooseLicensePlate;
+// 开放接口 - 视频号
+export const reserveChannelsLive = wx.reserveChannelsLive;
+export const openChannelsUserProfile = wx.openChannelsUserProfile;
+export const openChannelsLive = wx.openChannelsLive;
+export const openChannelsEvent = wx.openChannelsEvent;
+export const openChannelsActivity = wx.openChannelsActivity;
+export const getChannelsShareKey = wx.getChannelsShareKey;
+export const getChannelsLiveNoticeInfo = wx.getChannelsLiveNoticeInfo;
+export const getChannelsLiveInfo = wx.getChannelsLiveInfo;
+// 开放接口 - 音视频通话
+export const requestDeviceVoIP = wx.requestDeviceVoIP;
+export const getDeviceVoIPList = wx.getDeviceVoIPList;
+// 开放接口 - 微信群
+export const getGroupEnterInfo = wx.getGroupEnterInfo;
+// 开放接口 - 隐私信息授权
+export const requirePrivacyAuthorize = wx.requirePrivacyAuthorize;
+export const openPrivacyContract = wx.openPrivacyContract;
+export const onNeedPrivacyAuthorization = wx.onNeedPrivacyAuthorization;
+export const getPrivacySetting = wx.getPrivacySetting;
+// 开放接口 - 微信客服
+export const openCustomerServiceChat = wx.openCustomerServiceChat;
+// 开放接口 - 微信表情
+export const openStickerSetView = wx.openStickerSetView;
+export const openStickerIPView = wx.openStickerIPView;
+export const openSingleStickerView = wx.openSingleStickerView;
+// 设备 - 蓝牙通用
+export const stopBluetoothDevicesDiscovery = promisify(wx.stopBluetoothDevicesDiscovery);
+export const startBluetoothDevicesDiscovery = promisify(wx.startBluetoothDevicesDiscovery);
+export const openBluetoothAdapter = wx.openBluetoothAdapter;
+export const onBluetoothDeviceFound = wx.onBluetoothDeviceFound;
+export const onBluetoothAdapterStateChange = wx.onBluetoothAdapterStateChange;
+export const offBluetoothDeviceFound = wx.offBluetoothDeviceFound;
+export const offBluetoothAdapterStateChange = wx.offBluetoothAdapterStateChange;
+export const makeBluetoothPair = promisify(wx.makeBluetoothPair);
+export const isBluetoothDevicePaired = promisify(wx.isBluetoothDevicePaired);
+export const getConnectedBluetoothDevices = promisify(wx.getConnectedBluetoothDevices);
+export const getBluetoothDevices = promisify(wx.getBluetoothDevices);
+export const getBluetoothAdapterState = promisify(wx.getBluetoothAdapterState);
+export const closeBluetoothAdapter = promisify(wx.closeBluetoothAdapter);
+// 设备 - 蓝牙 - 低功耗中心设备
+export const writeBLECharacteristicValue = promisify(wx.writeBLECharacteristicValue);
+export const setBLEMTU = promisify(wx.setBLEMTU);
+export const readBLECharacteristicValue = promisify(wx.readBLECharacteristicValue);
+export const onBLEMTUChange = wx.onBLEMTUChange;
+export const onBLEConnectionStateChange = wx.onBLEConnectionStateChange;
+export const onBLECharacteristicValueChange = wx.onBLECharacteristicValueChange;
+export const offBLEMTUChange = wx.offBLEMTUChange;
+export const offBLEConnectionStateChange = wx.offBLEConnectionStateChange;
+export const offBLECharacteristicValueChange = wx.offBLECharacteristicValueChange;
+export const notifyBLECharacteristicValueChange = promisify(wx.notifyBLECharacteristicValueChange);
+export const getBLEMTU = promisify(wx.getBLEMTU);
+export const getBLEDeviceRSSI = promisify(wx.getBLEDeviceRSSI);
+export const getBLEDeviceCharacteristics = promisify(wx.getBLEDeviceCharacteristics);
+export const getBLEDeviceServices = promisify(wx.getBLEDeviceServices);
+export const createBLEConnection = promisify(wx.createBLEConnection);
+export const closeBLEConnection = promisify(wx.closeBLEConnection);
+// 设备 - 蓝牙 - 低功耗外围设备
+export const onBLEPeripheralConnectionStateChanged = wx.onBLEPeripheralConnectionStateChanged;
+export const offBLEPeripheralConnectionStateChanged = wx.offBLEPeripheralConnectionStateChanged;
+export const createBLEPeripheralServer = promisify(wx.createBLEPeripheralServer);
+// 设备 - 蓝牙 - 信标
+export const stopBeaconDiscovery = promisify(wx.stopBeaconDiscovery);
+export const startBeaconDiscovery = promisify(wx.startBeaconDiscovery);
+export const onBeaconUpdate = wx.onBeaconUpdate;
+export const offBeaconUpdate = wx.offBeaconUpdate;
+export const onBeaconServiceChange = wx.onBeaconServiceChange;
+export const offBeaconServiceChange = wx.offBeaconServiceChange;
+export const getBeacons = promisify(wx.getBeacons);
+// 设备 - NFC读写
+export const getNFCAdapter = wx.getNFCAdapter;
+// 设备 - WIFI
+export const stopWifi = promisify(wx.stopWifi);
+export const startWifi = promisify(wx.startWifi);
+export const setWifiList = promisify(wx.setWifiList);
+export const onWifiConnected = wx.onWifiConnected;
+export const onGetWifiList = wx.onGetWifiList;
+export const offWifiConnectedWithPartialInfo = wx.offWifiConnectedWithPartialInfo;
+export const offWifiConnected = wx.offWifiConnected;
+export const offGetWifiList = wx.offGetWifiList;
+export const getWifiList = promisify(wx.getWifiList);
+export const getConnectedWifi = promisify(wx.getConnectedWifi);
+export const connectWifi = promisify(wx.connectWifi);
+// 设备 - 日历
+export const addPhoneRepeatCalendar = promisify(wx.addPhoneRepeatCalendar);
+export const addPhoneCalendar = promisify(wx.addPhoneCalendar);
+// 设备 - 联系人
+export const chooseContact = wx.chooseContact;
+export const addPhoneContact = promisify(wx.addPhoneContact);
+// 设备 - 无障碍
+export const checkIsOpenAccessibility = promisify(wx.checkIsOpenAccessibility);
+// 设备 - 电量
+export const onBatteryInfoChange = wx.onBatteryInfoChange;
+export const offBatteryInfoChange = wx.offBatteryInfoChange;
+export const getBatteryInfoSync = promisify(wx.getBatteryInfoSync);
+export const getBatteryInfo = promisify(wx.getBatteryInfo);
+// 设备 - 剪贴板
+export const setClipboardData = promisify(wx.setClipboardData);
+export const getClipboardData = promisify(wx.getClipboardData);
+// 设备 - NFC 主机卡模拟
+export const stopHCE = promisify(wx.stopHCE);
+export const startHCE = promisify(wx.startHCE);
+export const sendHCEMessage = promisify(wx.sendHCEMessage);
+export const onHCEMessage = wx.onHCEMessage;
+export const offHCEMessage = wx.offHCEMessage;
+export const getHCEState = promisify(wx.getHCEState);
+// 设备 - 网络
+export const onNetworkWeakChange = wx.onNetworkWeakChange;
+export const onNetworkStatusChange = wx.onNetworkStatusChange;
+export const offNetworkStatusChange = wx.offNetworkStatusChange;
+export const getNetworkType = promisify(wx.getNetworkType);
+export const getLocalIPAddress = wx.getLocalIPAddress;
+// 设备 - 加密
+export const getRandomValues = promisify(wx.getRandomValues);
+// 设备 - 屏幕
+export const setVisualEffectOnCapture = wx.setVisualEffectOnCapture;
+export const setScreenBrightness = promisify(wx.setScreenBrightness);
+export const setKeepScreenOn = promisify(wx.setKeepScreenOn);
+export const onUserCaptureScreen = wx.onUserCaptureScreen;
+export const onScreenRecordingStateChanged = wx.onScreenRecordingStateChanged;
+export const offUserCaptureScreen = wx.offUserCaptureScreen;
+export const offScreenRecordingStateChanged = wx.offScreenRecordingStateChanged;
+export const getScreenRecordingState = wx.getScreenRecordingState;
+export const getScreenBrightness = promisify(wx.getScreenBrightness);
+// 设备 - 键盘
+export const onKeyUp = wx.onKeyUp;
+export const onKeyDown = wx.onKeyDown;
+export const onKeyboardHeightChange = wx.onKeyboardHeightChange;
+export const offKeyUp = wx.offKeyUp;
+export const offKeyDown = wx.offKeyDown;
+export const offKeyboardHeightChange = wx.offKeyboardHeightChange;
+export const hideKeyboard = promisify(wx.hideKeyboard);
+export const getSelectedTextRange = promisify(wx.getSelectedTextRange);
+// 设备 - 电话
+export const makePhoneCall = promisify(wx.makePhoneCall);
+// 设备 - 加速计
+export const stopAccelerometer = promisify(wx.stopAccelerometer);
+export const startAccelerometer = promisify(wx.startAccelerometer);
+export const onAccelerometerChange = wx.onAccelerometerChange;
+export const offAccelerometerChange = wx.offAccelerometerChange;
+// 设备 - 罗盘
+export const stopCompass = promisify(wx.stopCompass);
+export const startCompass = promisify(wx.startCompass);
+export const onCompassChange = wx.onCompassChange;
+export const offCompassChange = wx.offCompassChange;
+// 设备 - 设备方向
+export const stopDeviceMotionListening = promisify(wx.stopDeviceMotionListening);
+export const startDeviceMotionListening = promisify(wx.startDeviceMotionListening);
+export const onDeviceMotionChange = wx.onDeviceMotionChange;
+export const offDeviceMotionChange = wx.offDeviceMotionChange;
+// 设备 - 陀螺仪
+export const stopGyroscope = promisify(wx.stopGyroscope);
+export const startGyroscope = promisify(wx.startGyroscope);
+export const onGyroscopeChange = wx.onGyroscopeChange;
+export const offGyroscopeChange = wx.offGyroscopeChange;
+// 设备 - 内存
+export const onMemoryWarning = wx.onMemoryWarning;
+export const offMemoryWarning = wx.offMemoryWarning;
+// 设备 - 扫码
+export const scanCode = promisify(wx.scanCode);
+// 设备 - 短信
+export const sendSms = wx.sendSms;
+// 设备 - 震动
+export const vibrateShort = promisify(wx.vibrateShort);
+export const vibrateLong = promisify(wx.vibrateLong);
+// AI - AI推理
+export const getInferenceEnvInfo = wx.getInferenceEnvInfo;
+export const createInferenceSession = wx.createInferenceSession;
+// AI - 视觉算法
+export const isVKSupport = wx.isVKSupport;
+export const createVKSession = wx.createVKSession;
+// AI - 人脸检测
+export const stopFaceDetect = wx.stopFaceDetect;
+export const initFaceDetect = wx.initFaceDetect;
+export const faceDetect = wx.faceDetect;
+// Worker
+export const createWorker = wx.createWorker;
+// WXML
+export const createSelectorQuery = wx.createSelectorQuery;
+export const createIntersectionObserver = wx.createIntersectionObserver;
+// 第三方平台
+export const getExtConfigSync = wx.getExtConfigSync;
+export const getExtConfig = promisify(wx.getExtConfig);
+// 广告
+export const getShowSplashAdStatus = wx.getShowSplashAdStatus;
+export const createRewardedVideoAd = wx.createRewardedVideoAd;
+export const createInterstitialAd = wx.createInterstitialAd;

--- a/packages/rsmax-wechat/src/index.ts
+++ b/packages/rsmax-wechat/src/index.ts
@@ -1,2 +1,3 @@
-export * as component from './hostComponents';
-export * as types from './types';
+export * from './hostComponents';
+export * from './api';
+export * from './types';


### PR DESCRIPTION
恢复 小程序微信、支付宝、阿里的 api 接口
恢复  @rsmax/wechat 的用法

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated platform package entrypoints to provide flat, direct exports (instead of grouped namespace exports).
  * Removed explicit subpath `exports` (and related type mapping where applicable) from platform package configurations.

* **New Features**
  * Added/expanded root-level API surfaces for Alipay, Toutiao, and WeChat mini-programs, including Promise-based wrappers for many async APIs.

* **Tests**
  * Updated integration test fixture imports to match the new package entry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->