### PR TITLE
chore(babel-preset-rsmax): 收敛依赖包

### DIFF
--- a/packages/babel-preset-rsmax/package.json
+++ b/packages/babel-preset-rsmax/package.json
@@ -23,8 +23,6 @@
     "@babel/helper-plugin-utils": "^7.24.7",
     "@babel/preset-env": "^7.24.7",
     "@babel/preset-react": "^7.24.7",
-    "@babel/preset-typescript": "^7.24.7",
-    "babel-plugin-auto-import": "^1.0.5",
     "babel-plugin-macros": "^3.1.0",
     "lodash": "^4.17.15"
   },

--- a/packages/babel-preset-rsmax/src/index.ts
+++ b/packages/babel-preset-rsmax/src/index.ts
@@ -2,7 +2,6 @@ import { declare } from '@babel/helper-plugin-utils';
 
 interface PresetOption {
   react?: boolean | { [key: string]: any };
-  typescript?: any;
   decorators?: any;
   'class-properties'?: any;
   'throw-if-namespace'?: boolean;
@@ -13,7 +12,6 @@ function preset(api: any, presetOption: PresetOption) {
   api.assertVersion(7);
 
   const react = typeof presetOption.react === 'undefined' ? true : presetOption.react;
-  const typescript = typeof presetOption.typescript === 'undefined' ? true : presetOption.typescript;
   const throwIfNamespace =
     typeof presetOption['throw-if-namespace'] === 'undefined' ? false : presetOption['throw-if-namespace'];
   const targets =
@@ -23,10 +21,6 @@ function preset(api: any, presetOption: PresetOption) {
 
   const presets: any[] = [[require.resolve('@babel/preset-env'), { targets }]];
 
-  if (typescript) {
-    presets.push([require.resolve('@babel/preset-typescript'), typeof typescript === 'object' ? typescript : {}]);
-  }
-
   if (react) {
     const defaultReactOpt = { throwIfNamespace, runtime: 'automatic' };
     const reactOpts = typeof react === 'boolean' ? defaultReactOpt : Object.assign(defaultReactOpt, react);
@@ -35,15 +29,7 @@ function preset(api: any, presetOption: PresetOption) {
 
   return {
     presets,
-    plugins: [
-      require.resolve('babel-plugin-macros'),
-      [
-        require.resolve('babel-plugin-auto-import'),
-        {
-          declarations: [{ default: 'regeneratorRuntime', path: 'regenerator-runtime' }],
-        },
-      ],
-    ],
+    plugins: [require.resolve('babel-plugin-macros')],
   };
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,12 +197,6 @@ importers:
       '@babel/preset-react':
         specifier: ^7.24.7
         version: 7.27.1(@babel/core@7.27.1)
-      '@babel/preset-typescript':
-        specifier: ^7.24.7
-        version: 7.27.1(@babel/core@7.27.1)
-      babel-plugin-auto-import:
-        specifier: ^1.0.5
-        version: 1.1.0
       babel-plugin-macros:
         specifier: ^3.1.0
         version: 3.1.0
@@ -2920,9 +2914,6 @@ packages:
 
   '@types/node@18.19.100':
     resolution: {integrity: sha512-ojmMP8SZBKprc3qGrGk8Ujpo80AXkrP7G2tOT4VWr5jlr5DHjsJF+emXJz+Wm0glmy4Js62oKMdZZ6B9Y+tEcA==}
-
-  '@types/node@25.9.3':
-    resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -7081,9 +7072,6 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
-  undici-types@7.24.6:
-    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
-
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
@@ -10768,10 +10756,6 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@25.9.3':
-    dependencies:
-      undici-types: 7.24.6
-
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/parse-json@4.0.2': {}
@@ -13073,7 +13057,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 18.19.100
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -15526,8 +15510,6 @@ snapshots:
       through: 2.3.8
 
   undici-types@5.26.5: {}
-
-  undici-types@7.24.6: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 


### PR DESCRIPTION
移除 @babel/preset-typescript 
移除 babel-plugin-auto-import

让转义在 swc-loader 中处理，收敛 babel-preset-rsmax 的功能