### PR TITLE
chore(cli): 迁移 Rsdoctor 为插件

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        node-version: [18, 20]
+        os: [ ubuntu-latest ]
+        node-version: [ 20 ]
     steps:
       - uses: actions/checkout@v4
       - name: 安装 pnpm

--- a/packages/rsmax-cli/package.json
+++ b/packages/rsmax-cli/package.json
@@ -29,7 +29,7 @@
     "@babel/helper-module-imports": "^7.7.4",
     "@babel/parser": "^7.7.4",
     "@babel/types": "^7.7.4",
-    "@rsdoctor/cli": "^1.2.3",
+    "@rsdoctor/cli": "^1.5.0",
     "@rsdoctor/rspack-plugin": "^1.1.2",
     "@rsmax/build-store": "workspace:*",
     "@rsmax/macro": "workspace:*",

--- a/packages/rsmax-cli/src/build/rspack/config.mini.ts
+++ b/packages/rsmax-cli/src/build/rspack/config.mini.ts
@@ -1,7 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { execute } from '@rsdoctor/cli';
-import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
 import Store from '@rsmax/build-store';
 import { slash } from '@rsmax/shared';
 import type { Options } from '@rsmax/types';
@@ -10,7 +8,6 @@ import moduleResolver from 'babel-plugin-module-resolver';
 import hostComponent from 'babel-plugin-rsmax-host-component';
 import * as Lifecycle from 'babel-plugin-rsmax-lifecycle';
 import ejs from 'ejs';
-import { logger } from 'rslog';
 import Config from 'rspack-chain';
 import type API from '../../API';
 import { moduleMatcher, targetExtensions } from '../../extensions';
@@ -218,18 +215,7 @@ export default function rspackConfig(builder: Builder): Configuration {
   }
 
   if (builder.options.analyze) {
-    config.plugin('rspack-bundle-analyzer').use(RsdoctorRspackPlugin, [
-      {
-        disableClientServer: true,
-      },
-    ]);
-    setTimeout(() => {
-      execute('analyze', {
-        profile: `./${builder.options.output}/.rsdoctor/manifest.json`,
-      }).then(r => {
-        logger.success('已生成分析报告');
-      });
-    }, 5000);
+    config.plugin('rsmax-rsdoctor-plugin').use(RsmaxPlugins.RsdoctorAnalyze, [{ output: builder.options.output }]);
   }
 
   const context = {

--- a/packages/rsmax-cli/src/build/rspack/config.miniComponent.ts
+++ b/packages/rsmax-cli/src/build/rspack/config.miniComponent.ts
@@ -1,7 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { execute } from '@rsdoctor/cli';
-import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
 import Store from '@rsmax/build-store';
 import { slash } from '@rsmax/shared';
 import type { Options } from '@rsmax/types';
@@ -9,7 +7,6 @@ import { type Configuration, rspack } from '@rspack/core';
 import hostComponent from 'babel-plugin-rsmax-host-component';
 import * as Lifecycle from 'babel-plugin-rsmax-lifecycle';
 import ejs from 'ejs';
-import { logger } from 'rslog';
 import Config from 'rspack-chain';
 import { moduleMatcher, targetExtensions } from '../../extensions';
 import type Builder from '../Builder';
@@ -196,18 +193,7 @@ export default function rspackConfig(builder: Builder): Configuration {
   config.plugin('rsmax-native-asset-plugin').use(RsmaxPlugins.NativeAsset, [builder]);
 
   if (builder.options.analyze) {
-    config.plugin('rspack-bundle-analyzer').use(RsdoctorRspackPlugin, [
-      {
-        disableClientServer: true,
-      },
-    ]);
-    setTimeout(() => {
-      execute('analyze', {
-        profile: `./${builder.options.output}/.rsdoctor/manifest.json`,
-      }).then(r => {
-        logger.success('已生成分析报告');
-      });
-    }, 5000);
+    config.plugin('rsmax-rsdoctor-plugin').use(RsmaxPlugins.RsdoctorAnalyze, [{ output: builder.options.output }]);
   }
 
   const context = {

--- a/packages/rsmax-cli/src/build/rspack/config.miniPlugin.ts
+++ b/packages/rsmax-cli/src/build/rspack/config.miniPlugin.ts
@@ -1,7 +1,5 @@
 import fs from 'node:fs';
 import * as path from 'node:path';
-import { execute } from '@rsdoctor/cli';
-import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
 import Store from '@rsmax/build-store';
 import { slash } from '@rsmax/shared';
 import type { Options } from '@rsmax/types';
@@ -9,7 +7,6 @@ import { type Configuration, rspack } from '@rspack/core';
 import hostComponent from 'babel-plugin-rsmax-host-component';
 import * as Lifecycle from 'babel-plugin-rsmax-lifecycle';
 import ejs from 'ejs';
-import { logger } from 'rslog';
 import Config from 'rspack-chain';
 import { moduleMatcher, targetExtensions } from '../../extensions';
 import type Builder from '../Builder';
@@ -201,18 +198,7 @@ export default function rspackConfig(builder: Builder): Configuration {
   config.plugin('rsmax-native-asset-plugin').use(RsmaxPlugins.NativeAsset, [builder]);
 
   if (builder.options.analyze) {
-    config.plugin('rspack-bundle-analyzer').use(RsdoctorRspackPlugin, [
-      {
-        disableClientServer: true,
-      },
-    ]);
-    setTimeout(() => {
-      execute('analyze', {
-        profile: `./${builder.options.output}/.rsdoctor/manifest.json`,
-      }).then(r => {
-        logger.success('已生成分析报告');
-      });
-    }, 3000);
+    config.plugin('rsmax-rsdoctor-plugin').use(RsmaxPlugins.RsdoctorAnalyze, [{ output: builder.options.output }]);
   }
 
   const context = {

--- a/packages/rsmax-cli/src/build/rspack/plugins/RsdoctorAnalyze.ts
+++ b/packages/rsmax-cli/src/build/rspack/plugins/RsdoctorAnalyze.ts
@@ -1,0 +1,85 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { execute } from '@rsdoctor/cli';
+import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
+import type { Compiler, RspackPluginInstance } from '@rspack/core';
+import { logger } from 'rslog';
+
+const PLUGIN_NAME = 'RsmaxRsdoctorPlugin';
+
+export interface RsdoctorAnalyzePluginOptions {
+  output: string;
+  timeout?: number;
+  interval?: number;
+  disableClientServer?: boolean;
+}
+
+export default class RsdoctorAnalyzePlugin implements RspackPluginInstance {
+  private options: Required<RsdoctorAnalyzePluginOptions>;
+
+  constructor(options: RsdoctorAnalyzePluginOptions) {
+    this.options = {
+      timeout: 15000,
+      interval: 200,
+      disableClientServer: true,
+      ...options,
+    };
+  }
+
+  apply(compiler: Compiler) {
+    new RsdoctorRspackPlugin({
+      disableClientServer: this.options.disableClientServer,
+    }).apply(compiler);
+
+    const manifestPath = path.resolve(
+      compiler.context,
+      `.${path.sep}${this.options.output}`,
+      '.rsdoctor',
+      'manifest.json'
+    );
+
+    const onDone = () => {
+      this.waitForManifest(manifestPath).then(exists => {
+        if (!exists) {
+          logger.warn(`未找到 manifest 文件: ${manifestPath}, 已跳过分析报告生成`);
+          return;
+        }
+        execute('analyze', {
+          profile: `./${this.options.output}/.rsdoctor/manifest.json`,
+        })
+          .then(() => {
+            logger.success('已生成分析报告');
+          })
+          .catch(err => {
+            logger.error(err);
+          });
+      });
+    };
+
+    if (typeof compiler.hooks?.done?.tap === 'function') {
+      compiler.hooks.done.tap(PLUGIN_NAME, onDone);
+    } else if (typeof (compiler as any).plugin === 'function') {
+      (compiler as any).plugin('done', onDone);
+    }
+  }
+
+  private waitForManifest(manifestPath: string): Promise<boolean> {
+    const { timeout, interval } = this.options;
+    const start = Date.now();
+
+    return new Promise<boolean>(resolve => {
+      const check = () => {
+        if (fs.existsSync(manifestPath)) {
+          resolve(true);
+          return;
+        }
+        if (Date.now() - start >= timeout) {
+          resolve(false);
+          return;
+        }
+        setTimeout(check, interval);
+      };
+      check();
+    });
+  }
+}

--- a/packages/rsmax-cli/src/build/rspack/plugins/RsdoctorAnalyze.ts
+++ b/packages/rsmax-cli/src/build/rspack/plugins/RsdoctorAnalyze.ts
@@ -56,11 +56,7 @@ export default class RsdoctorAnalyzePlugin implements RspackPluginInstance {
       });
     };
 
-    if (typeof compiler.hooks?.done?.tap === 'function') {
-      compiler.hooks.done.tap(PLUGIN_NAME, onDone);
-    } else if (typeof (compiler as any).plugin === 'function') {
-      (compiler as any).plugin('done', onDone);
-    }
+    compiler.hooks.done.tap(PLUGIN_NAME, onDone);
   }
 
   private waitForManifest(manifestPath: string): Promise<boolean> {

--- a/packages/rsmax-cli/src/build/rspack/plugins/index.ts
+++ b/packages/rsmax-cli/src/build/rspack/plugins/index.ts
@@ -8,3 +8,4 @@ export { default as CoverageIgnore } from './CoverageIgnore';
 export { default as PluginAsset } from './PluginAsset';
 export { default as NativeAsset } from './NativeAsset';
 export { default as WeChatRecompile } from './WeChatRecompile';
+export { default as RsdoctorAnalyze } from './RsdoctorAnalyze';

--- a/packages/rsmax-cli/src/build/rspack/webBaseConfig.ts
+++ b/packages/rsmax-cli/src/build/rspack/webBaseConfig.ts
@@ -1,12 +1,10 @@
 import fs from 'node:fs';
-import { execute } from '@rsdoctor/cli';
-import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
 import { rspack } from '@rspack/core';
-import { logger } from 'rslog';
 import type Config from 'rspack-chain';
 import { moduleMatcher, targetExtensions } from '../../extensions';
 import type Builder from '../Builder';
 import { type RuleConfig, addCSSRule, cssConfig } from './config/css';
+import * as RsmaxPlugins from './plugins';
 
 export default function webBaseConfig(config: Config, builder: Builder) {
   config.devtool(process.env.NODE_ENV === 'development' ? 'cheap-source-map' : false);
@@ -93,18 +91,7 @@ export default function webBaseConfig(config: Config, builder: Builder) {
   config.plugin('rspackbar').use(rspack.ProgressPlugin);
 
   if (builder.options.analyze) {
-    config.plugin('rspack-bundle-analyzer').use(RsdoctorRspackPlugin, [
-      {
-        disableClientServer: true,
-      },
-    ]);
-    setTimeout(() => {
-      execute('analyze', {
-        profile: `./${builder.options.output}/.rsdoctor/manifest.json`,
-      }).then(r => {
-        logger.success('已生成分析报告');
-      });
-    }, 5000);
+    config.plugin('rsmax-rsdoctor-plugin').use(RsmaxPlugins.RsdoctorAnalyze, [{ output: builder.options.output }]);
   }
 
   if (!builder.options.watch) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,7 +79,7 @@ importers:
     dependencies:
       '@rsmax/plugin-less':
         specifier: ^1.0.0
-        version: 1.0.1(@rspack/core@1.6.3(@swc/helpers@0.5.17))(rsmax@1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3)))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
+        version: 1.0.1(@rspack/core@1.6.3(@swc/helpers@0.5.17))(rsmax@1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3)))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
       antd-mini:
         specifier: ^2.15.0
         version: 2.36.9
@@ -91,7 +91,7 @@ importers:
         version: 18.3.1
       rsmax:
         specifier: '*'
-        version: 1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
+        version: 1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
     devDependencies:
       '@types/expect-puppeteer':
         specifier: ^4.4.0
@@ -125,7 +125,7 @@ importers:
         version: 16.14.0
       rsmax:
         specifier: '*'
-        version: 1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
+        version: 1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
 
   packages/babel-plugin-rsmax-host-component:
     dependencies:
@@ -297,8 +297,8 @@ importers:
         specifier: ^7.7.4
         version: 7.27.1
       '@rsdoctor/cli':
-        specifier: ^1.2.3
-        version: 1.2.3(@rsbuild/core@1.5.0(@emnapi/core@1.5.0)(@emnapi/runtime@1.5.0))(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
+        specifier: ^1.5.0
+        version: 1.5.13(@rsdoctor/client@1.5.13)(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
       '@rsdoctor/rspack-plugin':
         specifier: ^1.1.2
         version: 1.1.2(@rsbuild/core@1.5.0(@emnapi/core@1.5.0)(@emnapi/runtime@1.5.0))(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
@@ -2258,27 +2258,26 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rsdoctor/cli@1.2.3':
-    resolution: {integrity: sha512-ezwWPvJWCMcbCjVZAujPrJgzDXujC22tiL8m8eOJBVWgGj1ISj1qK/aFqQ/dDHmxqycgtMHo2cy+s2wGo5/Ujg==}
+  '@rsdoctor/cli@1.5.13':
+    resolution: {integrity: sha512-k634Ppcqn9MhZXij7S33B7AvIMX+dpd9YbrD9YYRqH1gvqPKBPM4B6VPpwSd+IJaLxa3quOhTYXrwa1e4SQ2rQ==}
     hasBin: true
+    peerDependencies:
+      '@rsdoctor/client': 1.5.13
 
   '@rsdoctor/client@1.1.2':
     resolution: {integrity: sha512-AHYShNzRhpThBiYVjecipEhvyJzkdjfICp7y4E149w2wucELTz2louQomUHEI+V7SMJmMCPlno3o/HDl23NRKA==}
 
-  '@rsdoctor/client@1.2.3':
-    resolution: {integrity: sha512-KzfRONtUFMOhgyd9Kur9C/eqh+qPE0UDQEwp/uCMIQHwmompGgChuGniVENd2mGgkZX4MDHubFSvjoeI7j4UBg==}
+  '@rsdoctor/client@1.5.13':
+    resolution: {integrity: sha512-pGc+Y6irGROjPBOAt7fMAiZwwtzS7dS5txcrioP8Q5MvJPGtcHxQ56IiUPl5i5faHBo0RSCwBESnslQPwjRGcg==}
 
   '@rsdoctor/core@1.1.2':
     resolution: {integrity: sha512-/SylDcroagJXCM5/0gEvrrDIJWeXXMcJ8fx/Ckb6L5DuriyeHoOZmoQTlJaGSQJZdWH74/wAzGJ8aLHnF23P7w==}
 
-  '@rsdoctor/core@1.2.3':
-    resolution: {integrity: sha512-7o+SoN0JVwvxi0LSToA9G5PvSDag9ri0pQ/krlsJdkg2aVCRSR1xVjS8pzaKR9F+Q5Mnj6RixYOhIkWqWoMWFw==}
-
   '@rsdoctor/graph@1.1.2':
     resolution: {integrity: sha512-U6tOsDJjzy1Nb8Xb04zepNcwR+GfIXB/N76yWnuBx/Q07c1RuUJS/P0/YkEo7CfgLq4e9HujgDlzewhANqlRYw==}
 
-  '@rsdoctor/graph@1.2.3':
-    resolution: {integrity: sha512-HYnUGnpWfkvrwex0VvfP4G5BTe/18bc03GHTM4iBwRuVkgi2PN1OkU/iGFSS3AbctnHLNQMC2NFuV8+U1wzynw==}
+  '@rsdoctor/graph@1.5.13':
+    resolution: {integrity: sha512-sImaFcLTg27m7PO5WOaH3ati3Vw64fvszBANae3ONXqb6F9EqpyLzyXTw7djqyvfVZsNObw+9LLmKJNevEmuyg==}
 
   '@rsdoctor/rspack-plugin@1.1.2':
     resolution: {integrity: sha512-5hp+mAKPHje9WtGILsF42KZ9MT4s/IF+LYKkNG9ior0m1W8aZBQNSaLy/hom1CLeYQ1LYKnjFcdsUlvDNkkSmg==}
@@ -2288,8 +2287,8 @@ packages:
   '@rsdoctor/sdk@1.1.2':
     resolution: {integrity: sha512-aplXFM/PXbFDYbFtZF+RTHGetDbQRnoS4BQfFE37BdsTBoCOP2AaG8Y6Jg5mrCn7D9JLmqugB+zJb/OxmXTHTQ==}
 
-  '@rsdoctor/sdk@1.2.3':
-    resolution: {integrity: sha512-kd6JQKNihmfwKrem2LhGih5MV6zb/RBNqnkuu/BDTuOClaKzq9JEbQlfYstGDv1yF3ECR/OEOCKNGNbnCbNtmg==}
+  '@rsdoctor/sdk@1.5.13':
+    resolution: {integrity: sha512-KCcKSR9B6cKUj3J0+EqzYf4up34WldD2MP2iUfUzGR+9OI/OSGzuirFMlGzV9cSFHWj0iJ5ydGSrXFvWDwmLkg==}
 
   '@rsdoctor/types@1.1.2':
     resolution: {integrity: sha512-DtCDXP+vzoPcnjwqycwpMuTfrPtd2+u4r/LPVkMSTotfGQC0PczwvW2B6rXtiIfEWWy3prCwXfb2fkinMh7UHg==}
@@ -2302,8 +2301,8 @@ packages:
       webpack:
         optional: true
 
-  '@rsdoctor/types@1.2.3':
-    resolution: {integrity: sha512-UMh4zdyKs3K4Jh7YQvHiaXKY9c7gFwCUcRaPtpB4XjlzE3lML21d0SBAXkGduwz9AmhuTRQCqaLKA2NNuDUivQ==}
+  '@rsdoctor/types@1.5.13':
+    resolution: {integrity: sha512-XBrxFQ45eB3QsF1B2P3AMowUis2cbDmFLOu8brtDovGTYypEiUlMAmVsdIhXKJrljkv47+j7GgTmUSUBarLM1g==}
     peerDependencies:
       '@rspack/core': '*'
       webpack: 5.x
@@ -2316,8 +2315,8 @@ packages:
   '@rsdoctor/utils@1.1.2':
     resolution: {integrity: sha512-pGPSc3HKXgNP6whQqX8HBbzrSsEmOlq/PJ0z0EpNeXeYC09u3WL0LTvoNQN/p7FldK/fS/cifCuYn+a+rdrv6w==}
 
-  '@rsdoctor/utils@1.2.3':
-    resolution: {integrity: sha512-HawWrcqXeqdhj4dKhdjJg4BXvstcQauYSRx0cnYH78f7z9PW60Smr6vYpByXC87rK3JKpa6CNiZi+qhI5yTAog==}
+  '@rsdoctor/utils@1.5.13':
+    resolution: {integrity: sha512-Z3O+92uRl6XrYJBDt2s0YAgkDszgjut85+kmM5wx+Z10Ha2o3ZmGp3FVLYBPz7TbKsay5RYxb2OLuJ39lrUQKg==}
 
   '@rsmax/ali@1.3.13':
     resolution: {integrity: sha512-wV4fgYMe/a945AUhTleiDmcPn0AZVGUqqd+VcuVf8SKDLW8CLgo+eD+f8vB2s2xF4vADQmk1BgxfDlQfEdZbuw==}
@@ -2986,6 +2985,9 @@ packages:
   '@types/tapable@2.2.7':
     resolution: {integrity: sha512-D6QzACV9vNX3r8HQQNTOnpG+Bv1rko+yEA82wKs3O9CQ5+XW7HI7TED17/UE7+5dIxyxZIWTxKbsBeF6uKFCwA==}
 
+  '@types/tapable@2.3.0':
+    resolution: {integrity: sha512-oMnbAXeVo+KUnje3hzdORXUbfnzTfqD0H92mLl19NE5hFqH9Q4ktq+xehNSxcNeeLm1COopYwa0zeP6Iz+oIXg==}
+
   '@types/uglify-js@3.17.5':
     resolution: {integrity: sha512-TU+fZFBTBcXj/GpDpDaBmgWk/gn96kMZ+uocaFUlV2f8a6WdMzzI44QBCmGcCiYR0Y6ZlNRiyUyKKt5nl/lbzQ==}
 
@@ -3091,6 +3093,10 @@ packages:
 
   acorn-walk@8.3.4:
     resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
+
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
     engines: {node: '>=0.4.0'}
 
   acorn@8.14.1:
@@ -3249,9 +3255,6 @@ packages:
 
   axios@0.25.0:
     resolution: {integrity: sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==}
-
-  axios@1.11.0:
-    resolution: {integrity: sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==}
 
   axios@1.9.0:
     resolution: {integrity: sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==}
@@ -4104,6 +4107,11 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  envinfo@7.21.0:
+    resolution: {integrity: sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   eol@0.9.1:
     resolution: {integrity: sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg==}
 
@@ -4138,6 +4146,9 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.47.1:
+    resolution: {integrity: sha512-5RAqEwf4P4E17p+W75KLOWw/nOvKZzSQpxM32IpI2KZLaVonjTrZ0Ai5ghMaVI9eKC2p8eoQgcBdkEDgzFk6+Q==}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -4356,10 +4367,6 @@ packages:
 
   form-data@4.0.2:
     resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
-    engines: {node: '>= 6'}
-
-  form-data@4.0.4:
-    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
 
   forwarded@0.2.0:
@@ -5086,6 +5093,9 @@ packages:
 
   launch-editor@2.10.0:
     resolution: {integrity: sha512-D7dBRJo/qcGX9xlvt/6wUYzQxjh5G1RvZPgPv8vi4KRU99DVQL/oW7tnVOCCTm2HGeo3C5HvGE5Yrh6UBoZ0vA==}
+
+  launch-editor@2.14.1:
+    resolution: {integrity: sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==}
 
   lazy-cache@0.2.7:
     resolution: {integrity: sha512-gkX52wvU/R8DVMMt78ATVPFMJqfW8FPz1GZ1sVHBVQHmu/WvhIWE4cE1GBzhJNFicDeYhnwp6Rl35BcAIM3YOQ==}
@@ -6468,12 +6478,13 @@ packages:
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
-  rslog@1.2.11:
-    resolution: {integrity: sha512-YgMMzQf6lL9q4rD9WS/lpPWxVNJ1ttY9+dOXJ0+7vJrKCAOT4GH0EiRnBi9mKOitcHiOwjqJPV1n/HRqqgZmOQ==}
-
   rslog@1.2.3:
     resolution: {integrity: sha512-antALPJaKBRPBU1X2q9t085K4htWDOOv/K1qhTUk7h0l1ePU/KbDqKJn19eKP0dk7PqMioeA0+fu3gyPXCsXxQ==}
     engines: {node: '>=14.17.6'}
+
+  rslog@2.1.3:
+    resolution: {integrity: sha512-DCUkRKUBR1lSpHKRcxNvHaYwGrUVf9MsoE1u6gd0CF37I8vwwtWc4b+FA9OwYZ4QA/shslzAYorD3MMfd+Rs/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   rsmax@1.3.13:
     resolution: {integrity: sha512-ff91PnYq12+W6ywfRX9fHzjNRS7OjkhFBBkj82zeh90xTisAmG78spdNtFkM+uCxlKSNeyJGPCnLuXIuZX3ujw==}
@@ -6556,11 +6567,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.7.2:
-    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   send@0.19.0:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
@@ -6608,6 +6614,10 @@ packages:
 
   shell-quote@1.8.2:
     resolution: {integrity: sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==}
+    engines: {node: '>= 0.4'}
+
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   shellwords@0.1.1:
@@ -6703,6 +6713,10 @@ packages:
   source-map@0.7.4:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
 
   sourcemapped-stacktrace@1.1.11:
     resolution: {integrity: sha512-O0pcWjJqzQFVsisPlPXuNawJHHg9N9UgpJ/aDmvi9+vnS3x1C0NhwkVFzzZ1VN0Xo+bekyweoqYvBw5ZBKiNnQ==}
@@ -6838,10 +6852,6 @@ packages:
 
   tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
-    engines: {node: '>=6'}
-
-  tapable@2.2.2:
-    resolution: {integrity: sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==}
     engines: {node: '>=6'}
 
   tapable@2.3.3:
@@ -9204,66 +9214,39 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 1.5.0(@emnapi/core@1.5.0)(@emnapi/runtime@1.5.0)
 
-  '@rsdoctor/cli@1.2.3(@rsbuild/core@1.5.0(@emnapi/core@1.5.0)(@emnapi/runtime@1.5.0))(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))':
+  '@rsdoctor/cli@1.5.13(@rsdoctor/client@1.5.13)(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))':
     dependencies:
-      '@rsdoctor/core': 1.2.3(@rsbuild/core@1.5.0(@emnapi/core@1.5.0)(@emnapi/runtime@1.5.0))(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
-      '@rsdoctor/sdk': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
-      '@rsdoctor/types': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
-      '@rsdoctor/utils': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
-      axios: 1.11.0
+      '@rsdoctor/client': 1.5.13
+      '@rsdoctor/graph': 1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
+      '@rsdoctor/sdk': 1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
+      '@rsdoctor/types': 1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
+      '@rsdoctor/utils': 1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
       ora: 5.4.1
-      picocolors: 1.1.1
-      yargs: 17.7.2
     transitivePeerDependencies:
-      - '@rsbuild/core'
       - '@rspack/core'
       - bufferutil
-      - debug
       - supports-color
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/cli@1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))':
+  '@rsdoctor/cli@1.5.13(@rsdoctor/client@1.5.13)(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))':
     dependencies:
-      '@rsdoctor/core': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
-      '@rsdoctor/sdk': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
-      '@rsdoctor/types': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
-      '@rsdoctor/utils': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
-      axios: 1.11.0
+      '@rsdoctor/client': 1.5.13
+      '@rsdoctor/graph': 1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
+      '@rsdoctor/sdk': 1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
+      '@rsdoctor/types': 1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
+      '@rsdoctor/utils': 1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
       ora: 5.4.1
-      picocolors: 1.1.1
-      yargs: 17.7.2
     transitivePeerDependencies:
-      - '@rsbuild/core'
       - '@rspack/core'
       - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-      - webpack
-
-  '@rsdoctor/cli@1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))':
-    dependencies:
-      '@rsdoctor/core': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
-      '@rsdoctor/sdk': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
-      '@rsdoctor/types': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
-      '@rsdoctor/utils': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
-      axios: 1.11.0
-      ora: 5.4.1
-      picocolors: 1.1.1
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@rsbuild/core'
-      - '@rspack/core'
-      - bufferutil
-      - debug
       - supports-color
       - utf-8-validate
       - webpack
 
   '@rsdoctor/client@1.1.2': {}
 
-  '@rsdoctor/client@1.2.3': {}
+  '@rsdoctor/client@1.5.13': {}
 
   '@rsdoctor/core@1.1.2(@rsbuild/core@1.5.0(@emnapi/core@1.5.0)(@emnapi/runtime@1.5.0))(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))':
     dependencies:
@@ -9343,81 +9326,6 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/core@1.2.3(@rsbuild/core@1.5.0(@emnapi/core@1.5.0)(@emnapi/runtime@1.5.0))(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))':
-    dependencies:
-      '@rsbuild/plugin-check-syntax': 1.3.0(@rsbuild/core@1.5.0(@emnapi/core@1.5.0)(@emnapi/runtime@1.5.0))
-      '@rsdoctor/graph': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
-      '@rsdoctor/sdk': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
-      '@rsdoctor/types': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
-      '@rsdoctor/utils': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
-      axios: 1.11.0
-      browserslist-load-config: 1.0.0
-      enhanced-resolve: 5.12.0
-      filesize: 10.1.6
-      fs-extra: 11.3.0
-      lodash: 4.17.21
-      path-browserify: 1.0.1
-      semver: 7.7.2
-      source-map: 0.7.4
-    transitivePeerDependencies:
-      - '@rsbuild/core'
-      - '@rspack/core'
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-      - webpack
-
-  '@rsdoctor/core@1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))':
-    dependencies:
-      '@rsbuild/plugin-check-syntax': 1.3.0(@rsbuild/core@1.5.0(@emnapi/core@1.5.0)(@emnapi/runtime@1.5.0))
-      '@rsdoctor/graph': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
-      '@rsdoctor/sdk': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
-      '@rsdoctor/types': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
-      '@rsdoctor/utils': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
-      axios: 1.11.0
-      browserslist-load-config: 1.0.0
-      enhanced-resolve: 5.12.0
-      filesize: 10.1.6
-      fs-extra: 11.3.0
-      lodash: 4.17.21
-      path-browserify: 1.0.1
-      semver: 7.7.2
-      source-map: 0.7.4
-    transitivePeerDependencies:
-      - '@rsbuild/core'
-      - '@rspack/core'
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-      - webpack
-
-  '@rsdoctor/core@1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))':
-    dependencies:
-      '@rsbuild/plugin-check-syntax': 1.3.0(@rsbuild/core@1.5.0(@emnapi/core@1.5.0)(@emnapi/runtime@1.5.0))
-      '@rsdoctor/graph': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
-      '@rsdoctor/sdk': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
-      '@rsdoctor/types': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
-      '@rsdoctor/utils': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
-      axios: 1.11.0
-      browserslist-load-config: 1.0.0
-      enhanced-resolve: 5.12.0
-      filesize: 10.1.6
-      fs-extra: 11.3.0
-      lodash: 4.17.21
-      path-browserify: 1.0.1
-      semver: 7.7.2
-      source-map: 0.7.4
-    transitivePeerDependencies:
-      - '@rsbuild/core'
-      - '@rspack/core'
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-      - webpack
-
   '@rsdoctor/graph@1.1.2(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))':
     dependencies:
       '@rsdoctor/types': 1.1.2(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
@@ -9446,26 +9354,26 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/graph@1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))':
+  '@rsdoctor/graph@1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))':
     dependencies:
-      '@rsdoctor/types': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
-      '@rsdoctor/utils': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
-      lodash.unionby: 4.8.0
-      source-map: 0.7.4
+      '@rsdoctor/types': 1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
+      '@rsdoctor/utils': 1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
+      es-toolkit: 1.47.1
+      path-browserify: 1.0.1
+      source-map: 0.7.6
     transitivePeerDependencies:
       - '@rspack/core'
-      - supports-color
       - webpack
 
-  '@rsdoctor/graph@1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))':
+  '@rsdoctor/graph@1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))':
     dependencies:
-      '@rsdoctor/types': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
-      '@rsdoctor/utils': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
-      lodash.unionby: 4.8.0
-      source-map: 0.7.4
+      '@rsdoctor/types': 1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
+      '@rsdoctor/utils': 1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
+      es-toolkit: 1.47.1
+      path-browserify: 1.0.1
+      source-map: 0.7.6
     transitivePeerDependencies:
       - '@rspack/core'
-      - supports-color
       - webpack
 
   '@rsdoctor/rspack-plugin@1.1.2(@rsbuild/core@1.5.0(@emnapi/core@1.5.0)(@emnapi/runtime@1.5.0))(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))':
@@ -9569,23 +9477,16 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/sdk@1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))':
+  '@rsdoctor/sdk@1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))':
     dependencies:
-      '@rsdoctor/client': 1.2.3
-      '@rsdoctor/graph': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
-      '@rsdoctor/types': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
-      '@rsdoctor/utils': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
-      '@types/fs-extra': 11.0.4
-      body-parser: 1.20.3
-      cors: 2.8.5
-      dayjs: 1.11.13
-      fs-extra: 11.3.0
-      json-cycle: 1.5.0
-      open: 8.4.2
-      sirv: 2.0.4
+      '@rsdoctor/client': 1.5.13
+      '@rsdoctor/graph': 1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
+      '@rsdoctor/types': 1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
+      '@rsdoctor/utils': 1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
+      launch-editor: 2.14.1
+      safer-buffer: 2.1.2
       socket.io: 4.8.1
-      source-map: 0.7.4
-      tapable: 2.2.2
+      tapable: 2.3.3
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -9593,23 +9494,16 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/sdk@1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))':
+  '@rsdoctor/sdk@1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))':
     dependencies:
-      '@rsdoctor/client': 1.2.3
-      '@rsdoctor/graph': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
-      '@rsdoctor/types': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
-      '@rsdoctor/utils': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
-      '@types/fs-extra': 11.0.4
-      body-parser: 1.20.3
-      cors: 2.8.5
-      dayjs: 1.11.13
-      fs-extra: 11.3.0
-      json-cycle: 1.5.0
-      open: 8.4.2
-      sirv: 2.0.4
+      '@rsdoctor/client': 1.5.13
+      '@rsdoctor/graph': 1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
+      '@rsdoctor/types': 1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
+      '@rsdoctor/utils': 1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
+      launch-editor: 2.14.1
+      safer-buffer: 2.1.2
       socket.io: 4.8.1
-      source-map: 0.7.4
-      tapable: 2.2.2
+      tapable: 2.3.3
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -9637,22 +9531,22 @@ snapshots:
       '@rspack/core': 1.6.3(@swc/helpers@0.5.17)
       webpack: 5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))
 
-  '@rsdoctor/types@1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))':
+  '@rsdoctor/types@1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))':
     dependencies:
       '@types/connect': 3.4.38
       '@types/estree': 1.0.5
-      '@types/tapable': 2.2.7
-      source-map: 0.7.4
+      '@types/tapable': 2.3.0
+      source-map: 0.7.6
     optionalDependencies:
       '@rspack/core': 1.6.3(@swc/helpers@0.5.17)
       webpack: 5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3)
 
-  '@rsdoctor/types@1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))':
+  '@rsdoctor/types@1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))':
     dependencies:
       '@types/connect': 3.4.38
       '@types/estree': 1.0.5
-      '@types/tapable': 2.2.7
-      source-map: 0.7.4
+      '@types/tapable': 2.3.0
+      source-map: 0.7.6
     optionalDependencies:
       '@rspack/core': 1.6.3(@swc/helpers@0.5.17)
       webpack: 5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))
@@ -9705,52 +9599,46 @@ snapshots:
       - supports-color
       - webpack
 
-  '@rsdoctor/utils@1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))':
+  '@rsdoctor/utils@1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@rsdoctor/types': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
+      '@rsdoctor/types': 1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
       '@types/estree': 1.0.5
-      acorn: 8.14.1
-      acorn-import-attributes: 1.9.5(acorn@8.14.1)
-      acorn-walk: 8.3.4
-      connect: 3.7.0
+      acorn: 8.17.0
+      acorn-import-attributes: 1.9.5(acorn@8.17.0)
+      acorn-walk: 8.3.5
       deep-eql: 4.1.4
-      envinfo: 7.14.0
-      filesize: 10.1.6
+      envinfo: 7.21.0
       fs-extra: 11.3.0
       get-port: 5.1.1
       json-stream-stringify: 3.0.1
       lines-and-columns: 2.0.4
       picocolors: 1.1.1
-      rslog: 1.2.11
+      rslog: 2.1.3
       strip-ansi: 6.0.1
     transitivePeerDependencies:
       - '@rspack/core'
-      - supports-color
       - webpack
 
-  '@rsdoctor/utils@1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))':
+  '@rsdoctor/utils@1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@rsdoctor/types': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
+      '@rsdoctor/types': 1.5.13(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
       '@types/estree': 1.0.5
-      acorn: 8.14.1
-      acorn-import-attributes: 1.9.5(acorn@8.14.1)
-      acorn-walk: 8.3.4
-      connect: 3.7.0
+      acorn: 8.17.0
+      acorn-import-attributes: 1.9.5(acorn@8.17.0)
+      acorn-walk: 8.3.5
       deep-eql: 4.1.4
-      envinfo: 7.14.0
-      filesize: 10.1.6
+      envinfo: 7.21.0
       fs-extra: 11.3.0
       get-port: 5.1.1
       json-stream-stringify: 3.0.1
       lines-and-columns: 2.0.4
       picocolors: 1.1.1
-      rslog: 1.2.11
+      rslog: 2.1.3
       strip-ansi: 6.0.1
     transitivePeerDependencies:
       - '@rspack/core'
-      - supports-color
       - webpack
 
   '@rsmax/ali@1.3.13(react-dom@18.3.1(react@16.14.0))(react@16.14.0)':
@@ -9800,18 +9688,18 @@ snapshots:
       - react
       - supports-color
 
-  '@rsmax/cli@1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(rsmax@1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))))(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))':
+  '@rsmax/cli@1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(rsmax@1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))))(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))':
     dependencies:
       '@babel/core': 7.27.1
       '@babel/helper-module-imports': 7.27.1
       '@babel/parser': 7.27.2
       '@babel/types': 7.27.1
-      '@rsdoctor/cli': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
+      '@rsdoctor/cli': 1.5.13(@rsdoctor/client@1.5.13)(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
       '@rsdoctor/rspack-plugin': 1.1.2(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
       '@rsmax/build-store': 1.3.13(react@16.14.0)
       '@rsmax/macro': 1.3.13(react@16.14.0)
       '@rsmax/plugin-devtools': 1.3.13(react@16.14.0)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
-      '@rsmax/plugin-error-screen': 1.3.13(react@16.14.0)(rsmax@1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))))
+      '@rsmax/plugin-error-screen': 1.3.13(react@16.14.0)(rsmax@1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))))
       '@rsmax/postcss-px2units': 0.2.1
       '@rsmax/postcss-tag': 1.3.13
       '@rsmax/runtime': 1.3.13(react-dom@18.3.1(react@16.14.0))(react@16.14.0)
@@ -9854,6 +9742,7 @@ snapshots:
       yargs-parser: 18.1.3
     transitivePeerDependencies:
       - '@rsbuild/core'
+      - '@rsdoctor/client'
       - '@swc/helpers'
       - '@swc/types'
       - '@types/express'
@@ -9868,18 +9757,18 @@ snapshots:
       - webpack
       - webpack-cli
 
-  '@rsmax/cli@1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rsmax@1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3)))(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))':
+  '@rsmax/cli@1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rsmax@1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3)))(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))':
     dependencies:
       '@babel/core': 7.27.1
       '@babel/helper-module-imports': 7.27.1
       '@babel/parser': 7.27.2
       '@babel/types': 7.27.1
-      '@rsdoctor/cli': 1.2.3(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
+      '@rsdoctor/cli': 1.5.13(@rsdoctor/client@1.5.13)(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
       '@rsdoctor/rspack-plugin': 1.1.2(@rspack/core@1.6.3(@swc/helpers@0.5.17))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
       '@rsmax/build-store': 1.3.13(react@18.3.1)
       '@rsmax/macro': 1.3.13(react@18.3.1)
       '@rsmax/plugin-devtools': 1.3.13(react@18.3.1)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
-      '@rsmax/plugin-error-screen': 1.3.13(react@18.3.1)(rsmax@1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3)))
+      '@rsmax/plugin-error-screen': 1.3.13(react@18.3.1)(rsmax@1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3)))
       '@rsmax/postcss-px2units': 0.2.1
       '@rsmax/postcss-tag': 1.3.13
       '@rsmax/runtime': 1.3.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9922,6 +9811,7 @@ snapshots:
       yargs-parser: 18.1.3
     transitivePeerDependencies:
       - '@rsbuild/core'
+      - '@rsdoctor/client'
       - '@swc/helpers'
       - '@swc/types'
       - '@types/express'
@@ -9954,11 +9844,11 @@ snapshots:
       - react
       - supports-color
 
-  '@rsmax/one@1.3.13(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(rsmax@1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))))':
+  '@rsmax/one@1.3.13(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(rsmax@1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))))':
     dependencies:
       '@rsmax/ali': 1.3.13(react-dom@18.3.1(react@16.14.0))(react@16.14.0)
       '@rsmax/framework-shared': 1.3.13
-      '@rsmax/redbox-react': 1.0.4(react@16.14.0)(rsmax@1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))))
+      '@rsmax/redbox-react': 1.0.4(react@16.14.0)(rsmax@1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))))
       '@rsmax/runtime': 1.3.13(react-dom@18.3.1(react@16.14.0))(react@16.14.0)
       '@rsmax/toutiao': 1.3.13(react@16.14.0)
       '@rsmax/web': 1.3.13(react-dom@18.3.1(react@16.14.0))(react@16.14.0)
@@ -9972,11 +9862,11 @@ snapshots:
       - rsmax
       - supports-color
 
-  '@rsmax/one@1.3.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rsmax@1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3)))':
+  '@rsmax/one@1.3.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rsmax@1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3)))':
     dependencies:
       '@rsmax/ali': 1.3.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@rsmax/framework-shared': 1.3.13
-      '@rsmax/redbox-react': 1.0.4(react@18.3.1)(rsmax@1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3)))
+      '@rsmax/redbox-react': 1.0.4(react@18.3.1)(rsmax@1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3)))
       '@rsmax/runtime': 1.3.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@rsmax/toutiao': 1.3.13(react@18.3.1)
       '@rsmax/web': 1.3.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -10014,9 +9904,9 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsmax/plugin-error-screen@1.3.13(react@16.14.0)(rsmax@1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))))':
+  '@rsmax/plugin-error-screen@1.3.13(react@16.14.0)(rsmax@1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))))':
     dependencies:
-      '@rsmax/redbox-react': 1.0.4(react@16.14.0)(rsmax@1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))))
+      '@rsmax/redbox-react': 1.0.4(react@16.14.0)(rsmax@1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))))
       '@rsmax/shared': 1.3.13(react@16.14.0)
       rspack-plugin-virtual-module: 1.0.1
     transitivePeerDependencies:
@@ -10024,9 +9914,9 @@ snapshots:
       - rsmax
       - supports-color
 
-  '@rsmax/plugin-error-screen@1.3.13(react@18.3.1)(rsmax@1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3)))':
+  '@rsmax/plugin-error-screen@1.3.13(react@18.3.1)(rsmax@1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3)))':
     dependencies:
-      '@rsmax/redbox-react': 1.0.4(react@18.3.1)(rsmax@1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3)))
+      '@rsmax/redbox-react': 1.0.4(react@18.3.1)(rsmax@1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3)))
       '@rsmax/shared': 1.3.13(react@18.3.1)
       rspack-plugin-virtual-module: 1.0.1
     transitivePeerDependencies:
@@ -10034,11 +9924,11 @@ snapshots:
       - rsmax
       - supports-color
 
-  '@rsmax/plugin-less@1.0.1(@rspack/core@1.6.3(@swc/helpers@0.5.17))(rsmax@1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3)))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))':
+  '@rsmax/plugin-less@1.0.1(@rspack/core@1.6.3(@swc/helpers@0.5.17))(rsmax@1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3)))(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))':
     dependencies:
       less: 4.3.0
       less-loader: 12.3.0(@rspack/core@1.6.3(@swc/helpers@0.5.17))(less@4.3.0)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
-      rsmax: 1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
+      rsmax: 1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
@@ -10050,22 +9940,22 @@ snapshots:
 
   '@rsmax/postcss-tag@1.3.13': {}
 
-  '@rsmax/redbox-react@1.0.4(react@16.14.0)(rsmax@1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))))':
+  '@rsmax/redbox-react@1.0.4(react@16.14.0)(rsmax@1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))))':
     dependencies:
       error-stack-parser-es: 1.0.5
       object-assign: 4.1.1
       prop-types: 15.8.1
       react: 16.14.0
-      rsmax: 1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
+      rsmax: 1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
       sourcemapped-stacktrace: 1.1.11
 
-  '@rsmax/redbox-react@1.0.4(react@18.3.1)(rsmax@1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3)))':
+  '@rsmax/redbox-react@1.0.4(react@18.3.1)(rsmax@1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3)))':
     dependencies:
       error-stack-parser-es: 1.0.5
       object-assign: 4.1.1
       prop-types: 15.8.1
       react: 18.3.1
-      rsmax: 1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
+      rsmax: 1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
       sourcemapped-stacktrace: 1.1.11
 
   '@rsmax/runtime@1.3.13(react-dom@18.3.1(react@16.14.0))(react@16.14.0)':
@@ -10830,6 +10720,10 @@ snapshots:
     dependencies:
       tapable: 2.2.1
 
+  '@types/tapable@2.3.0':
+    dependencies:
+      tapable: 2.3.3
+
   '@types/uglify-js@3.17.5':
     dependencies:
       source-map: 0.6.1
@@ -10975,9 +10869,17 @@ snapshots:
     dependencies:
       acorn: 8.14.1
 
+  acorn-import-attributes@1.9.5(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
   acorn-walk@8.3.4:
     dependencies:
       acorn: 8.14.1
+
+  acorn-walk@8.3.5:
+    dependencies:
+      acorn: 8.17.0
 
   acorn@8.14.1: {}
 
@@ -11119,14 +11021,6 @@ snapshots:
   axios@0.25.0:
     dependencies:
       follow-redirects: 1.15.9
-    transitivePeerDependencies:
-      - debug
-
-  axios@1.11.0:
-    dependencies:
-      follow-redirects: 1.15.9
-      form-data: 4.0.4
-      proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
 
@@ -12077,6 +11971,8 @@ snapshots:
 
   envinfo@7.14.0: {}
 
+  envinfo@7.21.0: {}
+
   eol@0.9.1: {}
 
   err-code@2.0.3: {}
@@ -12108,6 +12004,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  es-toolkit@1.47.1: {}
 
   escalade@3.2.0: {}
 
@@ -12368,14 +12266,6 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      mime-types: 2.1.35
-
-  form-data@4.0.4:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
       mime-types: 2.1.35
 
   forwarded@0.2.0: {}
@@ -13159,6 +13049,11 @@ snapshots:
     dependencies:
       picocolors: 1.1.1
       shell-quote: 1.8.2
+
+  launch-editor@2.14.1:
+    dependencies:
+      picocolors: 1.1.1
+      shell-quote: 1.8.4
 
   lazy-cache@0.2.7: {}
 
@@ -14834,16 +14729,16 @@ snapshots:
   rrweb-cssom@0.8.0:
     optional: true
 
-  rslog@1.2.11: {}
-
   rslog@1.2.3: {}
 
-  rsmax@1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))):
+  rslog@2.1.3: {}
+
+  rsmax@1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))):
     dependencies:
       '@rsmax/ali': 1.3.13(react-dom@18.3.1(react@16.14.0))(react@16.14.0)
-      '@rsmax/cli': 1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(rsmax@1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))))(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
+      '@rsmax/cli': 1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(rsmax@1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))))(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17)))
       '@rsmax/macro': 1.3.13(react@16.14.0)
-      '@rsmax/one': 1.3.13(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(rsmax@1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))))
+      '@rsmax/one': 1.3.13(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(rsmax@1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@16.14.0))(react@16.14.0)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))))
       '@rsmax/runtime': 1.3.13(react-dom@18.3.1(react@16.14.0))(react@16.14.0)
       '@rsmax/toutiao': 1.3.13(react@16.14.0)
       '@rsmax/types': 1.3.13
@@ -14851,6 +14746,7 @@ snapshots:
       '@rsmax/wechat': 1.3.13(react-dom@18.3.1(react@16.14.0))(react@16.14.0)
     transitivePeerDependencies:
       - '@rsbuild/core'
+      - '@rsdoctor/client'
       - '@swc/helpers'
       - '@swc/types'
       - '@types/express'
@@ -14864,12 +14760,12 @@ snapshots:
       - webpack
       - webpack-cli
 
-  rsmax@1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3)):
+  rsmax@1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3)):
     dependencies:
       '@rsmax/ali': 1.3.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@rsmax/cli': 1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rsmax@1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3)))(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
+      '@rsmax/cli': 1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rsmax@1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3)))(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3))
       '@rsmax/macro': 1.3.13(react@18.3.1)
-      '@rsmax/one': 1.3.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rsmax@1.3.13(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3)))
+      '@rsmax/one': 1.3.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rsmax@1.3.13(@rsdoctor/client@1.5.13)(@swc/helpers@0.5.17)(@swc/types@0.1.21)(@types/express@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.99.8(@swc/core@1.11.29(@swc/helpers@0.5.17))(postcss@8.5.3)))
       '@rsmax/runtime': 1.3.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@rsmax/toutiao': 1.3.13(react@18.3.1)
       '@rsmax/types': 1.3.13
@@ -14877,6 +14773,7 @@ snapshots:
       '@rsmax/wechat': 1.3.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - '@rsbuild/core'
+      - '@rsdoctor/client'
       - '@swc/helpers'
       - '@swc/types'
       - '@types/express'
@@ -14970,8 +14867,6 @@ snapshots:
 
   semver@7.7.1: {}
 
-  semver@7.7.2: {}
-
   send@0.19.0:
     dependencies:
       debug: 2.6.9
@@ -15041,6 +14936,8 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shell-quote@1.8.2: {}
+
+  shell-quote@1.8.4: {}
 
   shellwords@0.1.1: {}
 
@@ -15166,6 +15063,8 @@ snapshots:
   source-map@0.6.1: {}
 
   source-map@0.7.4: {}
+
+  source-map@0.7.6: {}
 
   sourcemapped-stacktrace@1.1.11:
     dependencies:
@@ -15315,8 +15214,6 @@ snapshots:
     optional: true
 
   tapable@2.2.1: {}
-
-  tapable@2.2.2: {}
 
   tapable@2.3.3: {}
 


### PR DESCRIPTION
改进：迁移 Rsdoctor 为 rspack 插件，而不是散落再各个构建文件中的配置。并且使用 done rspack 构建 hook 使得分析报告更为稳定。而不是使用之前的 setTimeout 方式。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `@rsdoctor/cli` dependency to version 1.5.0.
  * Refactored build analysis reporting mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->