### PR TITLE
chore(one): 使用 react-textarea-autosize 代替 react-autosize-textarea

### DIFF
--- a/packages/rsmax-one/package.json
+++ b/packages/rsmax-one/package.json
@@ -24,7 +24,7 @@
     "@rsmax/wechat": "workspace:*",
     "clsx": "^2.1.1",
     "memoize-one": "^5.1.1",
-    "react-autosize-textarea": "^7.0.0"
+    "react-textarea-autosize": "^8.5.3"
   },
   "devDependencies": {
     "@rsmax/types": "workspace:*",

--- a/packages/rsmax-one/src/hostComponents/Input/index.web.tsx
+++ b/packages/rsmax-one/src/hostComponents/Input/index.web.tsx
@@ -7,18 +7,18 @@ import type { InputWebProps } from './props';
 export type InputProps = InputWebProps;
 
 const Input: React.ForwardRefRenderFunction<any, InputWebProps> = (props, ref) => {
-  const { password, type, onConfirm, onKeyPress, placeholderStyle, className, ...restProps } = filterProps(props);
+  const { password, type, onConfirm, onKeyDown, placeholderStyle, className, ...restProps } = filterProps(props);
   const [placeholderStyleClassName] = useWebPlaceholderStyle(placeholderStyle);
 
   const inputType = password ? 'password' : type;
 
-  function handleKeyPress(e: React.KeyboardEvent<HTMLInputElement>) {
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     if (e.key === 'Enter' && typeof onConfirm === 'function') {
       onConfirm(e);
     }
 
-    if (typeof onKeyPress === 'function') {
-      onKeyPress(e);
+    if (typeof onKeyDown === 'function') {
+      onKeyDown(e);
     }
   }
 
@@ -27,7 +27,7 @@ const Input: React.ForwardRefRenderFunction<any, InputWebProps> = (props, ref) =
       {...restProps}
       ref={ref}
       type={inputType}
-      onKeyPress={handleKeyPress}
+      onKeyDown={handleKeyDown}
       className={clsx('remax-input', className, placeholderStyleClassName)}
     />
   );

--- a/packages/rsmax-one/src/hostComponents/Textarea/index.web.tsx
+++ b/packages/rsmax-one/src/hostComponents/Textarea/index.web.tsx
@@ -1,32 +1,40 @@
 import clsx from 'clsx';
-import * as React from 'react';
-import TextareaAutoSize from 'react-autosize-textarea';
+import React from 'react';
+import TextareaAutosize from 'react-textarea-autosize';
 import useWebPlaceholderStyle from '../../useWebPlaceholderStyle';
 import { filterProps } from '../../utils/isPlatformSpecifyProp';
 import type { TextareaWebProps } from './props';
 
 const Textarea: React.ForwardRefRenderFunction<any, TextareaWebProps> = (props, ref) => {
-  const { onConfirm, onKeyPress, autoHeight, className, placeholderStyle, ...restProps } = filterProps(props);
+  const { onConfirm, onKeyDown, autoHeight, className, placeholderStyle, ...restProps } = filterProps(props);
   const [placeholderStyleClassName] = useWebPlaceholderStyle(placeholderStyle);
 
-  function handleKeyPress(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
     if (e.key === 'Enter' && typeof onConfirm === 'function') {
       onConfirm(e);
     }
 
-    if (typeof onKeyPress === 'function') {
-      onKeyPress(e);
+    if (typeof onKeyDown === 'function') {
+      onKeyDown(e);
     }
   }
 
   const textareaClassName = clsx('remax-textarea', className, placeholderStyleClassName);
 
   if (autoHeight) {
-    // @ts-ignore
-    // todo 需要修正这里
-    return <TextareaAutoSize {...restProps} className={textareaClassName} ref={ref} onKeyPress={handleKeyPress} />;
+    const TextareaAutoSize = TextareaAutosize as unknown as React.ComponentType<
+      React.TextareaHTMLAttributes<HTMLTextAreaElement> & { ref?: React.Ref<HTMLTextAreaElement> }
+    >;
+    return (
+      <TextareaAutoSize
+        {...restProps}
+        className={textareaClassName}
+        ref={ref as React.Ref<HTMLTextAreaElement>}
+        onKeyDown={handleKeyDown}
+      />
+    );
   }
 
-  return <textarea {...restProps} className={textareaClassName} ref={ref} onKeyPress={handleKeyPress} />;
+  return <textarea {...restProps} className={textareaClassName} ref={ref} onKeyDown={handleKeyDown} />;
 };
 export default React.forwardRef(Textarea);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -584,9 +584,9 @@ importers:
       memoize-one:
         specifier: ^5.1.1
         version: 5.2.1
-      react-autosize-textarea:
-        specifier: ^7.0.0
-        version: 7.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-textarea-autosize:
+        specifier: ^8.5.3
+        version: 8.5.9(@types/react@18.3.21)(react@18.3.1)
     devDependencies:
       '@rsmax/types':
         specifier: workspace:*
@@ -2901,9 +2901,6 @@ packages:
 
   '@types/node@18.19.100':
     resolution: {integrity: sha512-ojmMP8SZBKprc3qGrGk8Ujpo80AXkrP7G2tOT4VWr5jlr5DHjsJF+emXJz+Wm0glmy4Js62oKMdZZ6B9Y+tEcA==}
-
-  '@types/node@25.9.3':
-    resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -6323,6 +6320,12 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-textarea-autosize@8.5.9:
+    resolution: {integrity: sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react@16.14.0:
     resolution: {integrity: sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==}
     engines: {node: '>=0.10.0'}
@@ -7073,9 +7076,6 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
-  undici-types@7.24.6:
-    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
-
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
@@ -7142,6 +7142,33 @@ packages:
 
   urlpattern-polyfill@9.0.0:
     resolution: {integrity: sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==}
+
+  use-composed-ref@1.4.0:
+    resolution: {integrity: sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-isomorphic-layout-effect@1.2.1:
+    resolution: {integrity: sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-latest@1.3.0:
+    resolution: {integrity: sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -10636,10 +10663,6 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@25.9.3':
-    dependencies:
-      undici-types: 7.24.6
-
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/parse-json@4.0.2': {}
@@ -12941,7 +12964,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 18.19.100
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -14573,6 +14596,15 @@ snapshots:
       react-shallow-renderer: 16.15.0(react@18.3.1)
       scheduler: 0.23.2
 
+  react-textarea-autosize@8.5.9(@types/react@18.3.21)(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.1
+      react: 18.3.1
+      use-composed-ref: 1.4.0(@types/react@18.3.21)(react@18.3.1)
+      use-latest: 1.3.0(@types/react@18.3.21)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+
   react@16.14.0:
     dependencies:
       loose-envify: 1.4.0
@@ -15402,8 +15434,6 @@ snapshots:
 
   undici-types@5.26.5: {}
 
-  undici-types@7.24.6: {}
-
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
   unicode-match-property-ecmascript@2.0.0:
@@ -15456,6 +15486,25 @@ snapshots:
   url-join@2.0.5: {}
 
   urlpattern-polyfill@9.0.0: {}
+
+  use-composed-ref@1.4.0(@types/react@18.3.21)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.21
+
+  use-isomorphic-layout-effect@1.2.1(@types/react@18.3.21)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.21
+
+  use-latest@1.3.0(@types/react@18.3.21)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      use-isomorphic-layout-effect: 1.2.1(@types/react@18.3.21)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.21
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated keyboard event handling in input and textarea fields for more reliable Enter key interactions.
* **Chores**
  * Refreshed textarea auto-sizing library dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->