### PR TITLE
refactor: 使用 rslog 重构 loglevel

### DIFF
--- a/packages/rsmax-cli/src/build/MiniBuilder.ts
+++ b/packages/rsmax-cli/src/build/MiniBuilder.ts
@@ -1,6 +1,6 @@
 import type { Options } from '@rsmax/types';
 import type { Configuration } from '@rspack/core';
-import { logger } from 'rslog';
+import { logger } from '../logger';
 import type API from '../API';
 import BaseBuilder from './Builder';
 import rspackConfig from './rspack/config.mini';
@@ -43,7 +43,7 @@ export default class MiniBuilder extends BaseBuilder {
 
       if (stats?.hasWarnings()) {
         info?.warnings?.forEach(warn => {
-          console.warn(warn.message);
+          logger.warn(warn.message);
         });
       }
     });
@@ -66,7 +66,7 @@ export default class MiniBuilder extends BaseBuilder {
 
       if (stats?.hasWarnings()) {
         info?.warnings?.forEach(warn => {
-          console.warn(warn.message);
+          logger.warn(warn.message);
         });
       }
     });

--- a/packages/rsmax-cli/src/build/MiniComponentBuilder.ts
+++ b/packages/rsmax-cli/src/build/MiniComponentBuilder.ts
@@ -1,6 +1,6 @@
 import type { Options } from '@rsmax/types';
 import type { Configuration } from '@rspack/core';
-import { logger } from 'rslog';
+import { logger } from '../logger';
 import type API from '../API';
 import Builder from './Builder';
 import rspackConfig from './rspack/config.miniComponent';
@@ -26,7 +26,7 @@ export default class MiniPluginBuilder extends Builder {
   watch() {
     this.rspackCompiler.watch({}, (error, stats) => {
       if (error) {
-        console.log(error);
+        logger.log(error);
         logger.error(error.message);
         throw error;
       }
@@ -40,7 +40,7 @@ export default class MiniPluginBuilder extends Builder {
       }
 
       if (stats?.hasWarnings()) {
-        console.warn(info?.warnings?.join('\n'));
+        logger.warn(info?.warnings?.join('\n'));
       }
     });
   }
@@ -64,7 +64,7 @@ export default class MiniPluginBuilder extends Builder {
 
       if (stats?.hasWarnings()) {
         info?.warnings?.forEach(warning => {
-          console.warn(warning);
+          logger.warn(warning);
         });
       }
     });

--- a/packages/rsmax-cli/src/build/MiniPluginBuilder.ts
+++ b/packages/rsmax-cli/src/build/MiniPluginBuilder.ts
@@ -1,6 +1,6 @@
 import type { Options } from '@rsmax/types';
 import type { Configuration } from '@rspack/core';
-import { logger } from 'rslog';
+import { logger } from '../logger';
 import type API from '../API';
 import Builder from './Builder';
 import rspackConfig from './rspack/config.miniPlugin';
@@ -26,7 +26,7 @@ export default class MiniPluginBuilder extends Builder {
   watch() {
     this.rspackCompiler.watch({}, (error, stats) => {
       if (error) {
-        console.log(error);
+        logger.log(error);
         logger.error(error.message);
         throw error;
       }
@@ -40,7 +40,7 @@ export default class MiniPluginBuilder extends Builder {
       }
 
       if (stats?.hasWarnings()) {
-        console.warn(info?.warnings?.join('\n'));
+        logger.warn(info?.warnings?.join('\n'));
       }
     });
   }
@@ -64,7 +64,7 @@ export default class MiniPluginBuilder extends Builder {
 
       if (stats?.hasWarnings()) {
         info?.warnings?.forEach(warning => {
-          console.warn(warning);
+          logger.warn(warning);
         });
       }
     });

--- a/packages/rsmax-cli/src/build/WebBuilder.ts
+++ b/packages/rsmax-cli/src/build/WebBuilder.ts
@@ -2,7 +2,7 @@ import type { Options } from '@rsmax/types';
 import type { Configuration } from '@rspack/core';
 import { RspackDevServer } from '@rspack/dev-server';
 import detect from 'detect-port';
-import { logger } from 'rslog';
+import { logger } from '../logger';
 import type API from '../API';
 import Builder from './Builder';
 import rspackConfig from './rspack/config.web';
@@ -43,7 +43,7 @@ export default class WebBuilder extends Builder {
       const server = new RspackDevServer({ port }, this.rspackCompiler);
 
       this.rspackCompiler.hooks.done.tap('web-dev', stats => {
-        console.log(
+        logger.log(
           stats.toString({
             colors: true,
             modules: false,
@@ -56,7 +56,7 @@ export default class WebBuilder extends Builder {
 
       server.startCallback(error => {
         if (error) {
-          console.error(error);
+          logger.error(error);
           process.exit(1);
         }
       });

--- a/packages/rsmax-cli/src/build/entries/NativeEntry.ts
+++ b/packages/rsmax-cli/src/build/entries/NativeEntry.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import { slash } from '@rsmax/shared';
 import type { LoaderContext } from '@rspack/core';
-import { logger } from 'rslog';
+import { logger } from '../../logger';
 import type Builder from '../Builder';
 import NativeAssets from '../NativeAssets';
 import { getNativeAssetOutputPath, replaceExtension } from '../utils/paths';

--- a/packages/rsmax-cli/src/build/index.ts
+++ b/packages/rsmax-cli/src/build/index.ts
@@ -1,6 +1,6 @@
 import type { Options } from '@rsmax/types';
 import type { Compiler } from '@rspack/core';
-import { logger } from 'rslog';
+import { logger, setupLogger } from '../logger';
 import API from '../API';
 
 const version = require('../../package.json').version;
@@ -8,6 +8,7 @@ const version = require('../../package.json').version;
 export function run(options: Options, api: API): Compiler {
   process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
+  setupLogger(options.loglevel);
   api.onBuildStart(options);
 
   if (options.target === 'web') {
@@ -30,6 +31,7 @@ export function internalBuildApp(options: Options, api: API) {
   const { target } = options;
   process.env.RSMAX_PLATFORM = target;
 
+  setupLogger(options.loglevel);
   logger.greet(`Rsmax v${version}`);
   logger.start('🚀 构建应用');
   return run(options, api);
@@ -41,6 +43,7 @@ export function buildMiniPlugin(options: Options) {
   const { target } = options;
   process.env.RSMAX_PLATFORM = target;
 
+  setupLogger(options.loglevel);
   logger.greet(`Rsmax v${version}`);
   logger.start('🔨 构建插件');
 
@@ -57,6 +60,7 @@ export function buildMiniComponent(options: Options) {
   const { target } = options;
   process.env.RSMAX_PLATFORM = target;
 
+  setupLogger(options.loglevel);
   logger.greet(`Rsmax v${version}`);
   logger.start('🔨 构建组件');
 

--- a/packages/rsmax-cli/src/build/rspack/plugins/OptimizeEntries.ts
+++ b/packages/rsmax-cli/src/build/rspack/plugins/OptimizeEntries.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { slash } from '@rsmax/shared';
 import { type Chunk, type ChunkGroup, Compilation, type Compiler, sources } from '@rspack/core';
+import { logger } from '../../../logger';
 
 const PLUGIN_NAME = 'RsmaxOptimizeEntriesPlugin';
 
@@ -43,7 +44,7 @@ class OptimizeEntriesPlugin {
               }
             }
           } catch (error) {
-            console.error(`[${PLUGIN_NAME}] Error:`, error);
+            logger.error(`[${PLUGIN_NAME}] Error:`, error);
             throw error;
           }
         }
@@ -87,7 +88,7 @@ class OptimizeEntriesPlugin {
         } else {
           // 仅在调试模式下输出警告
           if (process.env.NODE_ENV !== 'production') {
-            console.warn(`[${PLUGIN_NAME}] Asset not found: ${assetPath}`);
+            logger.warn(`[${PLUGIN_NAME}] Asset not found: ${assetPath}`);
           }
         }
       }

--- a/packages/rsmax-cli/src/build/rspack/plugins/PageAsset/index.ts
+++ b/packages/rsmax-cli/src/build/rspack/plugins/PageAsset/index.ts
@@ -1,5 +1,6 @@
 import { type Compiler, EntryPlugin } from '@rspack/core';
 import SourceCache from '../../../../SourceCache';
+import { logger } from '../../../../logger';
 import type Builder from '../../../Builder';
 import PageEntry from '../../../entries/PageEntry';
 import { clearComponentsCache } from '../getUsingComponents';
@@ -28,7 +29,7 @@ export default class PageAssetPlugin {
           const dep = EntryPlugin.createDependency(entry.virtualPath);
           compilation.addEntry('', dep, { name: entry.name }, err => {
             if (err) {
-              console.error(err);
+              logger.error(err);
             }
           });
         }

--- a/packages/rsmax-cli/src/build/rspack/plugins/RsdoctorAnalyze.ts
+++ b/packages/rsmax-cli/src/build/rspack/plugins/RsdoctorAnalyze.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { execute } from '@rsdoctor/cli';
 import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
 import type { Compiler, RspackPluginInstance } from '@rspack/core';
-import { logger } from 'rslog';
+import { logger } from '../../../logger';
 
 const PLUGIN_NAME = 'RsmaxRsdoctorPlugin';
 

--- a/packages/rsmax-cli/src/build/utils/alias.ts
+++ b/packages/rsmax-cli/src/build/utils/alias.ts
@@ -13,7 +13,7 @@ const resolveReact = (options: Options): string => {
     react = require.resolve(`${options.cwd}/node_modules/react/`);
   } catch (e) {
     react = require.resolve('react');
-    logger.warn(`Can't resolve react in ${options.cwd}!`);
+    logger.debug(`Can't resolve react in ${options.cwd}, fallback to global react.`);
   }
   return path.dirname(slash(react));
 };

--- a/packages/rsmax-cli/src/build/utils/alias.ts
+++ b/packages/rsmax-cli/src/build/utils/alias.ts
@@ -1,6 +1,7 @@
 import * as path from 'node:path';
 import { slash } from '@rsmax/shared';
 import type { Options, Platform } from '@rsmax/types';
+import { logger } from '../../logger';
 
 interface Alias {
   [key: string]: string;
@@ -12,7 +13,7 @@ const resolveReact = (options: Options): string => {
     react = require.resolve(`${options.cwd}/node_modules/react/`);
   } catch (e) {
     react = require.resolve('react');
-    console.warn(`Can't resolve react in ${options.cwd}!`);
+    logger.warn(`Can't resolve react in ${options.cwd}!`);
   }
   return path.dirname(slash(react));
 };

--- a/packages/rsmax-cli/src/index.ts
+++ b/packages/rsmax-cli/src/index.ts
@@ -74,7 +74,6 @@ export default class RsmaxCLI {
             .option('loglevel', {
               describe: '展示日志级别',
               type: 'string',
-              default: 'verbose',
             });
         },
         (argv: any) => {

--- a/packages/rsmax-cli/src/logger.ts
+++ b/packages/rsmax-cli/src/logger.ts
@@ -1,0 +1,36 @@
+import { logger as rslogLogger, type LogLevel as RslogLogLevel } from 'rslog';
+import type { LogLevel } from '@rsmax/types';
+
+const LEVEL_MAP: Record<LogLevel, RslogLogLevel> = {
+  debug: 'verbose',
+  verbose: 'verbose',
+  info: 'info',
+  warn: 'warn',
+  error: 'error',
+  silent: 'error',
+};
+
+let initialized = false;
+
+export function setupLogger(level: LogLevel = 'verbose') {
+  if (initialized) return;
+
+  if (level === 'silent') {
+    rslogLogger.override({
+      error: () => {},
+      warn: () => {},
+      info: () => {},
+      start: () => {},
+      ready: () => {},
+      success: () => {},
+      log: () => {},
+      debug: () => {},
+    });
+  } else {
+    rslogLogger.level = LEVEL_MAP[level];
+  }
+
+  initialized = true;
+}
+
+export const logger = rslogLogger;

--- a/packages/rsmax-cli/src/logger.ts
+++ b/packages/rsmax-cli/src/logger.ts
@@ -12,10 +12,12 @@ const LEVEL_MAP: Record<LogLevel, RslogLogLevel> = {
 
 let initialized = false;
 
-export function setupLogger(level: LogLevel = 'verbose') {
+export function setupLogger(level?: LogLevel) {
   if (initialized) return;
 
-  if (level === 'silent') {
+  const effectiveLevel: LogLevel = level ?? 'verbose';
+
+  if (effectiveLevel === 'silent') {
     rslogLogger.override({
       error: () => {},
       warn: () => {},
@@ -27,7 +29,7 @@ export function setupLogger(level: LogLevel = 'verbose') {
       debug: () => {},
     });
   } else {
-    rslogLogger.level = LEVEL_MAP[level];
+    rslogLogger.level = LEVEL_MAP[effectiveLevel];
   }
 
   initialized = true;

--- a/packages/rsmax-cli/tests/setup.ts
+++ b/packages/rsmax-cli/tests/setup.ts
@@ -8,7 +8,9 @@ import { diff } from 'jest-diff';
 import { sortBy } from 'lodash';
 import * as eol from 'eol';
 import { slash } from '@rsmax/shared';
-import { logger } from 'rslog';
+import { logger, setupLogger } from '../src/logger';
+
+setupLogger('silent');
 
 type Received = Array<{
   fileName: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified logging framework across all CLI build modules for consistent message output and configuration.

* **Changes**
  * The `--loglevel` CLI option no longer defaults to 'verbose' when unspecified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->