### PR TITLE
chore: 使用 engines 对 node 版本和 PNPM 版本进行限制

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clean": "lerna clean",
     "clean:packages": "lerna run clean",
     "format": "prettier --write .",
-    "lint": "biome check . --diagnostic-level=warn",
+    "lint": "rslint .",
     "prepack": "pnpm run readme:copy",
     "postpack": "pnpm run readme:clean",
     "readme:clean": "lerna exec 'rm README.md' --scope rsmax --scope @rsmax/cli",
@@ -30,13 +30,13 @@
   "nano-staged": {
     "*.{md,mdx,json,css,less,scss}": "prettier --write",
     "*.{js,jsx,ts,tsx,mjs,cjs}": [
-      "biome check --write --formatter-enabled=false --linter-enabled=false --no-errors-on-unmatched",
+      "rslint --fix",
       "prettier --write"
     ]
   },
   "devDependencies": {
     "@babel/types": "^7.7.4",
-    "@biomejs/biome": "1.9.4",
+    "@rslint/core": "^0.6.2",
     "@rstest/core": "^0.6.4",
     "@types/babel-plugin-tester": "^9.0.0",
     "@types/babel__core": "^7.7.4",
@@ -44,7 +44,7 @@
     "@types/express": "^4.17.4",
     "@types/jest": "^27.5.2",
     "@types/lodash": "^4.14.135",
-    "@types/node": "^18.19",
+    "@types/node": "^20.19",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "@types/react-test-renderer": "^18.3.0",
@@ -57,5 +57,9 @@
     "rsmax": "workspace:*",
     "simple-git-hooks": "^2.13.0",
     "typescript": "^4.7.4"
+  },
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0",
+    "pnpm": "^10.0.0"
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting tooling and development dependencies
  * Specified minimum required Node.js and pnpm versions for the project

<!-- end of auto-generated comment: release notes by coderabbit.ai -->