### PR TITLE
chore: 修改 e2e 中的 navigationBarTitleText

### DIFF
--- a/e2e/src/packageA/pages/detail/index.json
+++ b/e2e/src/packageA/pages/detail/index.json
@@ -1,0 +1,3 @@
+{
+  "navigationBarTitleText": "subpackage 演示"
+}

--- a/e2e/src/pages/hooks/hooks.json
+++ b/e2e/src/pages/hooks/hooks.json
@@ -1,0 +1,3 @@
+{
+  "navigationBarTitleText": "Hooks 演示"
+}

--- a/e2e/src/pages/i18n-demo/index.json
+++ b/e2e/src/pages/i18n-demo/index.json
@@ -1,3 +1,3 @@
 {
-  "usingComponents": {}
+  "navigationBarTitleText": "i18n 演示"
 }

--- a/e2e/src/pages/index/index.json
+++ b/e2e/src/pages/index/index.json
@@ -1,3 +1,3 @@
 {
-  "navigationBarTitleText": "首页"
+  "navigationBarTitleText": "Rsmax 演示"
 }

--- a/e2e/src/pages/store-demo/index.json
+++ b/e2e/src/pages/store-demo/index.json
@@ -1,4 +1,3 @@
 {
-  "navigationBarTitleText": "rsmax-store 示例",
-  "usingComponents": {}
+  "navigationBarTitleText": "store 演示"
 }

--- a/e2e/src/pages/ui-demo/ui-demo.json
+++ b/e2e/src/pages/ui-demo/ui-demo.json
@@ -1,0 +1,4 @@
+{
+  "navigationBarTitleText": "Vant UI 演示",
+  "usingComponents": {}
+}

--- a/e2e/src/pages/wxs-demo/index.json
+++ b/e2e/src/pages/wxs-demo/index.json
@@ -1,3 +1,3 @@
 {
-  "navigationBarTitleText": "WXS 支持 Demo"
+  "navigationBarTitleText": "WXS 演示"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated page titles throughout the demo app for clearer, more consistent labeling.
  * Added descriptive titles for the subpackage, Hooks, internationalization, store, UI, and WXS demo pages.
  * Renamed the home page title to “Rsmax 演示” and standardized related demo titles using consistent “演示” wording.
  * Added the missing UI demo page title, displayed as “Vant UI 演示”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->